### PR TITLE
fixed searching issue for veggie and meats, updated location seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 
 ### Unsolved Problems:
 * Backbone + Single Page Application
+* Searching by Cost and Popularity (specifically sending in the query hasn't been implemented. Not specifically a problem)
 * David Beeler
 
 [Martin Ryan](https://github.com/martin-ryan) - Git Leader <br>

--- a/db/seeds/LocationsSeed.json
+++ b/db/seeds/LocationsSeed.json
@@ -1,34 +1,50 @@
   {
-    "name": "Bowsers Between the Bunz",
-    "address": "333 Stewart Street, Chicago, IL, 60655",
+    "name": "Skywalker's Bistro",
+    "address": "743 Newkirk Avenue, Chicago, IL, 60640",
     "coords": [
-      -87.644384,
-      41.904304
+      -87.671002,
+      41.925145
     ],
-    "phone": "+1 (849) 526-2993",
-    "website": "www.kyagoro.com",
-    "price": 3,
+    "phone": "+1 (809) 599-2709",
+    "website": "www.geofarm.com",
+    "price": 4,
     "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+    "veggie": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
     "burgers": [
       {
-        "name": "The Yummy Cheesy Sandwich",
-        "description": "Ullamco qui id dolor sit velit.",
-        "rating": 4,
+        "name": "The Jedi Master Double Sandwich",
+        "description": "Irure sit ullamco ut commodo excepteur labore tempor minim aliquip do.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Delicious Cheesy Burger",
+        "description": "Tempor et voluptate amet cupidatat reprehenderit id sint consectetur.",
+        "rating": 3,
         "veggie": false,
-        "image": "https://pixabay.com/get/e834b1062dfc063ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
         "meat": {
           "grassfed": false,
           "kobe": false,
-          "bison": false,
+          "bison": true,
           "angus": false,
           "turkey": true,
-          "lamb": true,
+          "lamb": false,
           "elk": true
         }
       }
@@ -38,23 +54,104 @@
       "kobe": false,
       "bison": false,
       "angus": false,
-      "turkey": true,
-      "lamb": true,
+      "turkey": false,
+      "lamb": false,
       "elk": false
     },
     "sides": {
-      "duckFries": false,
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Heavenly Devour",
+      "description": "Magna mollit pariatur tempor ut in."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Between the Bunz",
+    "address": "665 Hyman Court, Chicago, IL, 60624",
+    "coords": [
+      -87.698961,
+      41.925701
+    ],
+    "phone": "+1 (852) 493-2726",
+    "website": "www.microluxe.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+    "burgers": [
+      {
+        "name": "The King Kong Cheesy Burger",
+        "description": "Velit consequat deserunt eu ea ad esse.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Filling Smeared Burger",
+        "description": "Non pariatur amet dolor amet ea eu mollit ex ipsum irure id.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
       "tots": false,
-      "macAndCheese": true
+      "macAndCheese": false
     },
     "allergies": {
       "accommodates": false,
       "glutenFree": false
     },
     "challenges": {
-      "exists": false,
-      "name": "The Delectable Graze",
-      "description": "Dolore quis eiusmod non occaecat non ea Lorem laborum anim qui anim nulla qui qui."
+      "exists": true,
+      "name": "The Enticing Chew",
+      "description": "Do aliqua eiusmod aliquip incididunt in occaecat veniam eu excepteur."
     },
     "hours": {
       "days": "Monday - Sunday",
@@ -64,651 +161,51 @@
     }
   },
   {
-    "name": "Sue's BBQ",
-    "address": "682 Diamond Street, Chicago, IL, 60657",
+    "name": "Gluten-Free Fusion",
+    "address": "461 Verona Place, Chicago, IL, 60646",
     "coords": [
-      -87.731746,
-      41.88954
+      -87.722421,
+      41.925237
     ],
-    "phone": "+1 (837) 479-3052",
-    "website": "www.glukgluk.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
-    "burgers": [
-      {
-        "name": "The King Kong Greasy Burger",
-        "description": "Cillum tempor deserunt fugiat consectetur exercitation proident in adipisicing sit.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/eb34b50e2df71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Graze",
-      "description": "Laboris consectetur qui sint aute ad et commodo."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Chophouse",
-    "address": "527 Brooklyn Avenue, Chicago, IL, 60605",
-    "coords": [
-      -87.646978,
-      41.855904
-    ],
-    "phone": "+1 (916) 486-2243",
-    "website": "www.tetratrex.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
-    "burgers": [
-      {
-        "name": "The Scrum-dilly-omcious Quadruple Sandwich",
-        "description": "Elit officia officia deserunt nostrud excepteur dolor consectetur ipsum exercitation dolor non consectetur do.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ee3db20a2cfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Grilled Quadruple Burger",
-        "description": "Sit qui duis consequat officia velit eu labore aute reprehenderit mollit id.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e031b40c2af61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Scrum-dilly-omcious Quadruple Sandwich",
-        "description": "Amet qui ex aute sint ex culpa Lorem consequat culpa nisi amet.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ed36b5092dfc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Devour",
-      "description": "Exercitation nisi aute ullamco incididunt nulla et ullamco aute."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Organic Fusion",
-    "address": "865 Ditmars Street, Chicago, IL, 60605",
-    "coords": [
-      -87.677419,
-      41.890491
-    ],
-    "phone": "+1 (825) 466-3123",
-    "website": "www.uni.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
-    "burgers": [
-      {
-        "name": "The Grilled Greasy Burger",
-        "description": "Quis ex consequat occaecat culpa sint.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec36b5092df21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delightful Quadruple Burger",
-        "description": "Irure id do fugiat ullamco ex voluptate cillum voluptate tempor.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ea30b70e2ff41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": true,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Chew",
-      "description": "Laboris officia quis veniam tempor qui Lorem sunt sint deserunt laborum occaecat ut esse tempor."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bowsers Sandwiches",
-    "address": "343 Fillmore Avenue, Chicago, IL, 60601",
-    "coords": [
-      -87.691964,
-      41.845535
-    ],
-    "phone": "+1 (866) 455-2577",
-    "website": "www.signity.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delightful Quadruple Sandwich",
-        "description": "Amet exercitation cupidatat reprehenderit incididunt ut irure eu occaecat voluptate.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/eb30b60b2af61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Yummy Greasy Burger",
-        "description": "Eu et ipsum consectetur deserunt adipisicing duis ipsum eiusmod.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e137b60c28fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delicious Graze",
-      "description": "Non amet sit amet aliquip esse pariatur ea enim."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Pub",
-    "address": "849 Estate Road, Chicago, IL, 60607",
-    "coords": [
-      -87.705102,
-      41.884063
-    ],
-    "phone": "+1 (841) 564-3323",
-    "website": "www.vendblend.com",
-    "price": 3,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
-    "burgers": [
-      {
-        "name": "The Meaty Quadruple Burger",
-        "description": "Non aliqua cupidatat dolor in minim proident id magna labore quis proident officia sunt.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/eb34b50e2df71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Graze",
-      "description": "Est nisi enim laboris tempor."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Organic Bar",
-    "address": "371 Ludlam Place, Chicago, IL, 60624",
-    "coords": [
-      -87.670191,
-      41.847523
-    ],
-    "phone": "+1 (912) 583-3155",
-    "website": "www.kiggle.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
-    "burgers": [
-      {
-        "name": "The Sensational Double Sandwich",
-        "description": "Minim irure exercitation voluptate velit aliqua aute eu cupidatat duis ipsum pariatur.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee3db20a2df51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Graze",
-      "description": "Aliquip commodo consequat amet laborum magna non eu laboris nostrud minim eu."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "6:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Super Mario's Chophouse",
-    "address": "424 Ocean Avenue, Chicago, IL, 60604",
-    "coords": [
-      -87.689527,
-      41.850038
-    ],
-    "phone": "+1 (948) 420-3034",
-    "website": "www.eargo.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
-    "burgers": [
-      {
-        "name": "The Jedi Master Cheesy Sandwich",
-        "description": "Elit irure incididunt veniam reprehenderit id ipsum enim duis elit.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e031b40c2af51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Graze",
-      "description": "Nisi in ea ut do nostrud et veniam non dolor ea nulla nostrud ipsum."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Chophouse",
-    "address": "798 Reed Street, Chicago, IL, 60652",
-    "coords": [
-      -87.674183,
-      41.848498
-    ],
-    "phone": "+1 (894) 422-2374",
-    "website": "www.quantasis.com",
-    "price": 0,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
-    "burgers": [
-      {
-        "name": "The King Kong Triple Sandwich",
-        "description": "Id ipsum amet cupidatat dolore quis proident tempor in.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e030b00721f21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Thick Smeared Sandwich",
-        "description": "Lorem ex aute labore aute commodo sint.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ef32b7092bf11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Grilled Greasy Sandwich",
-        "description": "Nisi ipsum occaecat consequat elit esse laboris anim irure consequat eiusmod irure.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e031b90b28f71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Chew",
-      "description": "Non deserunt nulla aute et."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Lounge",
-    "address": "739 Porter Avenue, Chicago, IL, 60651",
-    "coords": [
-      -87.677651,
-      41.891998
-    ],
-    "phone": "+1 (987) 497-3322",
-    "website": "www.hotcakes.com",
+    "phone": "+1 (973) 481-2201",
+    "website": "www.plutorque.com",
     "price": 1,
-    "foodtruck": false,
+    "foodtruck": true,
     "veggie": false,
-    "byob": false,
-    "alcohol": true,
+    "byob": true,
+    "alcohol": false,
     "latenight": false,
     "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
     "burgers": [
       {
-        "name": "The Filling Quadruple Sandwich",
-        "description": "Dolor culpa consectetur deserunt aliqua magna.",
-        "rating": 1,
+        "name": "The Jedi Master Double Burger",
+        "description": "Fugiat ea incididunt ut deserunt do ea anim elit qui nulla.",
+        "rating": 2,
         "veggie": true,
-        "image": "https://pixabay.com/get/ef33b80d2df61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": false,
           "bison": true,
-          "angus": false,
+          "angus": true,
           "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Turbo Smeared Sandwich",
+        "description": "Amet labore exercitation dolore nostrud magna laborum dolore commodo duis.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
           "lamb": true,
           "elk": false
         }
@@ -718,15 +215,15 @@
       "grassfed": false,
       "kobe": true,
       "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
       "elk": false
     },
     "sides": {
-      "duckFries": false,
+      "duckFries": true,
       "tots": false,
-      "macAndCheese": true
+      "macAndCheese": false
     },
     "allergies": {
       "accommodates": false,
@@ -734,8 +231,8 @@
     },
     "challenges": {
       "exists": false,
-      "name": "The Delicious Graze",
-      "description": "Sit nostrud incididunt eiusmod labore pariatur culpa aliqua irure labore sunt nulla."
+      "name": "The Yummy Chew",
+      "description": "Anim adipisicing incididunt mollit incididunt voluptate enim tempor eu id."
     },
     "hours": {
       "days": "Monday - Sunday",
@@ -745,68 +242,538 @@
     }
   },
   {
-    "name": "Bowsers Tavern",
-    "address": "971 Navy Walk, Chicago, IL, 60624",
+    "name": "Sue's Chophouse",
+    "address": "301 Mersereau Court, Chicago, IL, 60649",
     "coords": [
-      -87.684888,
-      41.894833
+      -87.690018,
+      41.867885
     ],
-    "phone": "+1 (944) 581-2731",
-    "website": "www.assistix.com",
-    "price": 2,
+    "phone": "+1 (858) 573-2135",
+    "website": "www.cosmosis.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+    "burgers": [
+      {
+        "name": "The Enticing Smeared Burger",
+        "description": "Ipsum enim nostrud cillum nisi do enim voluptate enim occaecat ipsum nostrud do sit.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The King Kong Cheesy Burger",
+        "description": "Mollit sunt et ad adipisicing anim magna id dolor esse veniam veniam irure duis cupidatat.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Delectable Cheesy Burger",
+        "description": "Do aute nisi esse adipisicing consectetur officia occaecat amet consectetur labore.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Devour",
+      "description": "Proident est do labore culpa Lorem amet."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Skywalker's Bar",
+    "address": "297 Remsen Avenue, Chicago, IL, 60706",
+    "coords": [
+      -87.705852,
+      41.921952
+    ],
+    "phone": "+1 (849) 420-2359",
+    "website": "www.printspan.com",
+    "price": 3,
     "foodtruck": true,
     "veggie": false,
     "byob": true,
-    "alcohol": false,
+    "alcohol": true,
     "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
     "burgers": [
       {
-        "name": "The Thick Cheesy Burger",
-        "description": "Non quis dolor do amet est incididunt laboris do eiusmod laboris fugiat nisi.",
-        "rating": 0,
+        "name": "The Turbo Quadruple Burger",
+        "description": "Reprehenderit occaecat velit laborum enim fugiat reprehenderit ullamco sit ullamco sint.",
+        "rating": 3,
         "veggie": true,
-        "image": "https://pixabay.com/get/e03cb70f2bf31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
         "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
           "lamb": true,
           "elk": true
         }
       },
       {
-        "name": "The Grilled Quadruple Sandwich",
-        "description": "Nulla cupidatat nisi proident commodo mollit qui incididunt minim excepteur est proident consequat ad mollit.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb30c20fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "name": "The Heavenly Double Burger",
+        "description": "Voluptate aute nulla cupidatat sunt ad ut irure.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
         "meat": {
-          "grassfed": false,
-          "kobe": false,
+          "grassfed": true,
+          "kobe": true,
           "bison": false,
-          "angus": false,
-          "turkey": false,
+          "angus": true,
+          "turkey": true,
           "lamb": false,
           "elk": false
         }
       },
       {
-        "name": "The Jedi Master Double Burger",
-        "description": "Reprehenderit et elit excepteur commodo occaecat officia Lorem amet deserunt veniam in.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee37b10f2cfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "name": "The Heavenly Double Sandwich",
+        "description": "Aute Lorem pariatur ipsum in.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Enticing Chew",
+      "description": "Officia do non nulla dolor quis aliquip."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Bar",
+    "address": "832 Langham Street, Chicago, IL, 60621",
+    "coords": [
+      -87.682398,
+      41.904597
+    ],
+    "phone": "+1 (953) 508-2806",
+    "website": "www.geekfarm.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delectable Double Burger",
+        "description": "Est adipisicing cillum aliquip ipsum cillum aliquip aliquip sint ullamco veniam proident commodo do.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": true,
           "bison": true,
           "angus": false,
           "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": true,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Graze",
+      "description": "Est cupidatat voluptate occaecat occaecat pariatur minim cupidatat ad eiusmod id fugiat esse voluptate irure."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Organic Buffet",
+    "address": "168 Gates Avenue, Chicago, IL, 60624",
+    "coords": [
+      -87.702711,
+      41.897351
+    ],
+    "phone": "+1 (892) 572-3900",
+    "website": "www.enersave.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+    "burgers": [
+      {
+        "name": "The Yummy Triple Burger",
+        "description": "Tempor qui ullamco enim sit consectetur.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delectable Triple Burger",
+        "description": "Adipisicing excepteur ex eiusmod nulla minim ex adipisicing cupidatat nisi.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
           "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Chew",
+      "description": "Voluptate eu cillum velit officia voluptate sit."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "12:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Organic Lounge",
+    "address": "419 Coles Street, Chicago, IL, 60610",
+    "coords": [
+      -87.665671,
+      41.914357
+    ],
+    "phone": "+1 (914) 599-3113",
+    "website": "www.sulfax.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+    "burgers": [
+      {
+        "name": "The Thick Triple Burger",
+        "description": "Nisi et aliquip incididunt fugiat cupidatat aliquip ullamco do.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Yummy Graze",
+      "description": "Laboris mollit laborum laboris officia labore eu anim elit quis proident irure labore nisi."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Burgers",
+    "address": "129 Varet Street, Chicago, IL, 60640",
+    "coords": [
+      -87.649505,
+      41.929507
+    ],
+    "phone": "+1 (859) 541-3726",
+    "website": "www.zillar.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
+    "burgers": [
+      {
+        "name": "The King Kong Smeared Sandwich",
+        "description": "Ut adipisicing amet est in magna irure ipsum incididunt aliquip et sit.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delectable Cheesy Burger",
+        "description": "Lorem consectetur aute deserunt est dolor laborum magna fugiat aliqua culpa.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Delectable Greasy Burger",
+        "description": "Excepteur laborum aliqua dolore aute anim Lorem ad aliquip labore elit ullamco deserunt sint dolore.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Yummy Chew",
+      "description": "Aliquip ex sunt ut culpa ex labore est officia ea do labore officia adipisicing."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bowsers Fusion",
+    "address": "857 Malbone Street, Chicago, IL, 60018",
+    "coords": [
+      -87.699281,
+      41.882241
+    ],
+    "phone": "+1 (933) 427-2856",
+    "website": "www.boink.com",
+    "price": 2,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delicious Double Sandwich",
+        "description": "Non irure voluptate aliquip enim anim ut voluptate incididunt deserunt officia fugiat qui eiusmod consequat.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
           "elk": true
         }
       }
@@ -823,80 +790,48 @@
     "sides": {
       "duckFries": false,
       "tots": true,
-      "macAndCheese": false
+      "macAndCheese": true
     },
     "allergies": {
-      "accommodates": false,
-      "glutenFree": false
+      "accommodates": true,
+      "glutenFree": true
     },
     "challenges": {
-      "exists": false,
-      "name": "The Meaty Devour",
-      "description": "Culpa in in velit tempor irure consequat officia consectetur nostrud ad anim eiusmod non veniam."
+      "exists": true,
+      "name": "The Delicious Chew",
+      "description": "Nulla ullamco commodo aute minim incididunt et labore veniam aute aliquip ullamco pariatur nostrud adipisicing."
     },
     "hours": {
       "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "5:00PM",
+      "opening": "9:00AM",
+      "closing": "10:00PM",
       "closed": false
     }
   },
   {
-    "name": "Super Mario's Flesh & Turkey",
-    "address": "884 Highlawn Avenue, Chicago, IL, 60641",
+    "name": "Super Mario's Bar",
+    "address": "177 Irving Avenue, Chicago, IL, 60619",
     "coords": [
-      -87.704793,
-      41.861471
+      -87.712433,
+      41.84984
     ],
-    "phone": "+1 (832) 529-3422",
-    "website": "www.equitox.com",
-    "price": 3,
+    "phone": "+1 (913) 545-3866",
+    "website": "www.quinex.com",
+    "price": 4,
     "foodtruck": true,
-    "veggie": true,
+    "veggie": false,
     "byob": true,
-    "alcohol": true,
+    "alcohol": false,
     "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
     "burgers": [
       {
-        "name": "The Delectable Cheesy Sandwich",
-        "description": "Incididunt cupidatat quis ut nisi in id.",
+        "name": "The Filling Smeared Sandwich",
+        "description": "Amet exercitation sunt velit duis quis commodo Lorem.",
         "rating": 1,
         "veggie": false,
-        "image": "https://pixabay.com/get/e131b4082df41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The King Kong Smeared Burger",
-        "description": "Sunt magna commodo incididunt veniam tempor exercitation commodo adipisicing id velit nostrud irure mollit sit.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e03db60d2df21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Enticing Greasy Sandwich",
-        "description": "Proident ullamco ex ea ad qui cillum sit fugiat.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/eb35b60d21f11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": false,
@@ -904,72 +839,23 @@
           "angus": false,
           "turkey": true,
           "lamb": true,
-          "elk": true
+          "elk": false
         }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Enticing Chew",
-      "description": "Cupidatat aliquip do magna eiusmod magna ea non mollit excepteur enim deserunt irure consectetur sunt."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Chophouse",
-    "address": "979 Vanderveer Place, Chicago, IL, 60610",
-    "coords": [
-      -87.731219,
-      41.876874
-    ],
-    "phone": "+1 (903) 515-2884",
-    "website": "www.turnabout.com",
-    "price": 0,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
-    "burgers": [
+      },
       {
-        "name": "The Thick Double Sandwich",
-        "description": "Lorem quis quis non fugiat.",
-        "rating": 2,
+        "name": "The King Kong Triple Sandwich",
+        "description": "Dolor occaecat ipsum fugiat velit dolore irure do enim mollit reprehenderit labore do.",
+        "rating": 1,
         "veggie": true,
-        "image": "https://pixabay.com/get/e037b60828f31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
         "meat": {
           "grassfed": false,
           "kobe": true,
           "bison": false,
           "angus": true,
-          "turkey": true,
+          "turkey": false,
           "lamb": false,
-          "elk": true
+          "elk": false
         }
       }
     ],
@@ -977,191 +863,13 @@
       "grassfed": false,
       "kobe": true,
       "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Heavenly Eat",
-      "description": "Culpa sunt aliquip aliqua tempor eiusmod."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "7:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Turbo Flesh & Turkey",
-    "address": "838 Keap Street, Chicago, IL, 60654",
-    "coords": [
-      -87.714082,
-      41.908091
-    ],
-    "phone": "+1 (932) 572-2380",
-    "website": "www.calcu.com",
-    "price": 1,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
-    "burgers": [
-      {
-        "name": "The Filling Quadruple Burger",
-        "description": "Mollit cillum sunt nulla laborum officia fugiat anim labore cillum qui.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/eb31b7072af61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Grilled Double Burger",
-        "description": "Occaecat ad labore pariatur labore Lorem pariatur nisi velit eu.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec33b10b2df31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Scrum-dilly-omcious Smeared Sandwich",
-        "description": "Labore anim est laborum dolore culpa consequat adipisicing sint fugiat duis ipsum.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e031b40c2af51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Devour",
-      "description": "Voluptate sunt minim consectetur reprehenderit ut sunt eu."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Super Mario's Fusion",
-    "address": "259 Leonard Street, Chicago, IL, 60656",
-    "coords": [
-      -87.735252,
-      41.870396
-    ],
-    "phone": "+1 (826) 419-2620",
-    "website": "www.mazuda.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delectable Cheesy Burger",
-        "description": "Ipsum laboris ad amet proident.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e835b7062cf2023ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Heavenly Triple Sandwich",
-        "description": "Nulla esse consequat aliquip sit dolor et anim.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec35b10f2df01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
       "angus": false,
-      "turkey": true,
-      "lamb": true,
+      "turkey": false,
+      "lamb": false,
       "elk": true
     },
     "sides": {
-      "duckFries": false,
+      "duckFries": true,
       "tots": true,
       "macAndCheese": true
     },
@@ -1171,60 +879,44 @@
     },
     "challenges": {
       "exists": true,
-      "name": "The Meaty Graze",
-      "description": "Laboris laborum labore officia est eu enim et et occaecat consectetur esse veniam reprehenderit."
+      "name": "The Enticing Graze",
+      "description": "Incididunt nostrud ut occaecat dolor laborum et mollit aute incididunt sint irure officia commodo consequat."
     },
     "hours": {
       "days": "Monday - Sunday",
-      "opening": "11:00AM",
+      "opening": "10:00AM",
       "closing": "5:00PM",
       "closed": false
     }
   },
   {
-    "name": "Tom's Cantina",
-    "address": "684 Columbia Street, Chicago, IL, 60603",
+    "name": "Gluten-Free Bar",
+    "address": "139 Lefferts Place, Chicago, IL, 60643",
     "coords": [
-      -87.714248,
-      41.926988
+      -87.721249,
+      41.927281
     ],
-    "phone": "+1 (813) 470-3625",
-    "website": "www.ronelon.com",
-    "price": 2,
+    "phone": "+1 (989) 595-2882",
+    "website": "www.entogrok.com",
+    "price": 1,
     "foodtruck": false,
     "veggie": true,
     "byob": false,
-    "alcohol": false,
-    "latenight": true,
+    "alcohol": true,
+    "latenight": false,
     "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
     "burgers": [
       {
-        "name": "The Thick Cheesy Burger",
-        "description": "Pariatur cillum tempor in exercitation sunt ad.",
-        "rating": 2,
+        "name": "The Sensational Quadruple Burger",
+        "description": "Culpa nulla ipsum aute est labore occaecat minim exercitation anim.",
+        "rating": 1,
         "veggie": true,
-        "image": "https://pixabay.com/get/e137b60c28fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
         "meat": {
           "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Grilled Smeared Burger",
-        "description": "Minim sit eiusmod consectetur nisi id.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e133b90e2cf11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
+          "kobe": false,
+          "bison": false,
           "angus": true,
           "turkey": false,
           "lamb": true,
@@ -1235,14 +927,14 @@
     "meats": {
       "grassfed": true,
       "kobe": true,
-      "bison": true,
+      "bison": false,
       "angus": false,
       "turkey": true,
       "lamb": true,
-      "elk": true
+      "elk": false
     },
     "sides": {
-      "duckFries": false,
+      "duckFries": true,
       "tots": false,
       "macAndCheese": true
     },
@@ -1251,9 +943,90 @@
       "glutenFree": true
     },
     "challenges": {
+      "exists": false,
+      "name": "The Yummy Chew",
+      "description": "Proident sint esse et incididunt laboris ad velit tempor labore."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "5:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bowsers Fusion",
+    "address": "951 Coventry Road, Chicago, IL, 60628",
+    "coords": [
+      -87.662794,
+      41.842846
+    ],
+    "phone": "+1 (982) 421-3149",
+    "website": "www.aquamate.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+    "burgers": [
+      {
+        "name": "The Turbo Greasy Sandwich",
+        "description": "Mollit et magna eiusmod qui proident labore cupidatat.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Filling Greasy Burger",
+        "description": "Laborum nostrud laborum voluptate reprehenderit.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
       "exists": true,
-      "name": "The Delectable Chew",
-      "description": "Velit adipisicing veniam ullamco cupidatat irure non proident quis irure sunt aliqua."
+      "name": "The Delicious Eat",
+      "description": "Occaecat cillum anim sunt proident adipisicing ullamco commodo."
     },
     "hours": {
       "days": "Monday - Sunday",
@@ -1263,36 +1036,214 @@
     }
   },
   {
-    "name": "Gluten-Free Bar",
-    "address": "422 Pioneer Street, Chicago, IL, 60623",
+    "name": "Tom's Chophouse",
+    "address": "803 Rugby Road, Chicago, IL, 60632",
     "coords": [
-      -87.667909,
-      41.882657
+      -87.729301,
+      41.893338
     ],
-    "phone": "+1 (965) 576-3424",
-    "website": "www.exotechno.com",
+    "phone": "+1 (944) 498-2771",
+    "website": "www.sustenza.com",
     "price": 1,
     "foodtruck": true,
-    "veggie": false,
-    "byob": false,
+    "veggie": true,
+    "byob": true,
     "alcohol": true,
-    "latenight": false,
+    "latenight": true,
     "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
     "burgers": [
       {
-        "name": "The Heavenly Triple Burger",
-        "description": "Sit minim excepteur deserunt qui in ad nostrud nostrud officia pariatur ad cillum Lorem.",
-        "rating": 0,
+        "name": "The Enticing Triple Burger",
+        "description": "Eiusmod ad nisi voluptate qui dolore nisi laborum dolor veniam ex cillum dolore id consectetur.",
+        "rating": 4,
         "veggie": true,
-        "image": "https://pixabay.com/get/e13cb5082af01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
         "meat": {
           "grassfed": false,
           "kobe": true,
           "bison": false,
           "angus": false,
-          "turkey": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Jedi Master Quadruple Sandwich",
+        "description": "Ea elit consectetur adipisicing aute ut id elit officia nostrud occaecat cupidatat officia.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
           "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delicious Eat",
+      "description": "Consequat officia mollit in dolor velit sit ad."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Old Ben's Café",
+    "address": "914 Bokee Court, Chicago, IL, 60636",
+    "coords": [
+      -87.676671,
+      41.859404
+    ],
+    "phone": "+1 (861) 538-2026",
+    "website": "www.entality.com",
+    "price": 1,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delightful Triple Sandwich",
+        "description": "Culpa nisi fugiat commodo ad adipisicing ut proident proident nostrud incididunt non velit Lorem.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Jedi Master Smeared Burger",
+        "description": "Est amet elit consequat deserunt aliquip tempor culpa aute elit in dolore consectetur ut.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The King Kong Double Sandwich",
+        "description": "Ea commodo culpa officia mollit pariatur occaecat dolor duis minim adipisicing magna reprehenderit nisi.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Yummy Chew",
+      "description": "Duis consequat tempor eu ullamco adipisicing cupidatat."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Organic Between the Bunz",
+    "address": "505 Raleigh Place, Chicago, IL, 60609",
+    "coords": [
+      -87.689658,
+      41.86952
+    ],
+    "phone": "+1 (877) 539-2830",
+    "website": "www.yogasm.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+    "burgers": [
+      {
+        "name": "The Jedi Master Double Burger",
+        "description": "In qui in ullamco quis occaecat nostrud deserunt non.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
           "elk": true
         }
       }
@@ -1301,8 +1252,8 @@
       "grassfed": true,
       "kobe": true,
       "bison": false,
-      "angus": false,
-      "turkey": false,
+      "angus": true,
+      "turkey": true,
       "lamb": true,
       "elk": true
     },
@@ -1313,66 +1264,212 @@
     },
     "allergies": {
       "accommodates": true,
-      "glutenFree": true
+      "glutenFree": false
     },
     "challenges": {
-      "exists": false,
-      "name": "The Delicious Chew",
-      "description": "Pariatur exercitation id nostrud non nostrud magna."
+      "exists": true,
+      "name": "The Delicious Graze",
+      "description": "Proident commodo occaecat laboris non dolor deserunt anim."
     },
     "hours": {
       "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "8:00PM",
+      "opening": "10:00AM",
+      "closing": "5:00PM",
       "closed": false
     }
   },
   {
-    "name": "Tom's Bar",
-    "address": "509 High Street, Chicago, IL, 60644",
+    "name": "Old Ben's Buffet",
+    "address": "974 Schenck Court, Chicago, IL, 60614",
     "coords": [
-      -87.641073,
-      41.831792
+      -87.658297,
+      41.896698
     ],
-    "phone": "+1 (852) 524-2514",
-    "website": "www.stralum.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
+    "phone": "+1 (900) 479-3950",
+    "website": "www.limozen.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
     "alcohol": true,
-    "latenight": true,
+    "latenight": false,
     "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
     "burgers": [
       {
-        "name": "The Meaty Double Burger",
-        "description": "Eiusmod nulla voluptate amet ut dolore cillum sit exercitation mollit.",
+        "name": "The Enticing Quadruple Burger",
+        "description": "Labore reprehenderit officia veniam qui incididunt exercitation consectetur ut.",
         "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e030b00721f21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": false,
           "bison": false,
           "angus": true,
           "turkey": false,
-          "lamb": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Meaty Devour",
+      "description": "Enim in occaecat labore quis non culpa cillum qui."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Old Ben's Between the Bunz",
+    "address": "917 Fountain Avenue, Chicago, IL, 60613",
+    "coords": [
+      -87.689064,
+      41.860505
+    ],
+    "phone": "+1 (986) 505-3558",
+    "website": "www.fishland.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+    "burgers": [
+      {
+        "name": "The Turbo Triple Burger",
+        "description": "Minim et mollit qui occaecat quis velit dolor commodo consectetur.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Chew",
+      "description": "Do et et eiusmod officia do sunt mollit laborum exercitation proident tempor."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "12:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bowsers Bar",
+    "address": "956 Losee Terrace, Chicago, IL, 60601",
+    "coords": [
+      -87.727814,
+      41.827988
+    ],
+    "phone": "+1 (881) 515-2332",
+    "website": "www.eclipsent.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delicious Double Burger",
+        "description": "Fugiat deserunt aliquip culpa exercitation voluptate cupidatat veniam ut qui excepteur in.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
           "elk": true
         }
       },
       {
-        "name": "The Filling Smeared Burger",
-        "description": "Mollit et excepteur ad ut.",
-        "rating": 3,
+        "name": "The King Kong Quadruple Burger",
+        "description": "Ullamco irure et quis do exercitation fugiat.",
+        "rating": 4,
         "veggie": false,
-        "image": "https://pixabay.com/get/eb34b50e2df71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
         "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
           "angus": true,
           "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Yummy Quadruple Sandwich",
+        "description": "Ad excepteur incididunt officia sit cillum sit deserunt.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
           "lamb": false,
           "elk": false
         }
@@ -1383,7 +1480,104 @@
       "kobe": true,
       "bison": false,
       "angus": false,
-      "turkey": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delicious Graze",
+      "description": "Quis pariatur consectetur Lorem aute aliquip nulla ut magna."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Turbo Bar",
+    "address": "558 Gunther Place, Chicago, IL, 60642",
+    "coords": [
+      -87.721771,
+      41.87343
+    ],
+    "phone": "+1 (872) 594-3140",
+    "website": "www.danja.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+    "burgers": [
+      {
+        "name": "The Scrumtrulesant Smeared Burger",
+        "description": "Culpa irure irure nisi do adipisicing duis mollit sit consequat consectetur aliqua ex qui labore.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Turbo Greasy Burger",
+        "description": "Reprehenderit nisi dolore nulla ullamco consequat non est fugiat exercitation.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delightful Greasy Sandwich",
+        "description": "Officia do id sunt amet non tempor commodo ipsum esse culpa qui pariatur esse reprehenderit.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
       "lamb": true,
       "elk": true
     },
@@ -1399,2315 +1593,79 @@
     "challenges": {
       "exists": false,
       "name": "The Delectable Devour",
-      "description": "Cupidatat commodo ea exercitation cupidatat reprehenderit qui aliqua esse magna culpa veniam sit ut ut."
+      "description": "Eiusmod est velit ut in dolor."
     },
     "hours": {
       "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "7:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Organic Café",
-    "address": "500 Central Avenue, Chicago, IL, 60637",
-    "coords": [
-      -87.726065,
-      41.833521
-    ],
-    "phone": "+1 (873) 580-3629",
-    "website": "www.marqet.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
-    "burgers": [
-      {
-        "name": "The Sensational Cheesy Sandwich",
-        "description": "Ut labore deserunt in labore mollit voluptate magna quis irure qui nisi.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec37b30b2ef01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delightful Greasy Sandwich",
-        "description": "Excepteur ullamco adipisicing aliqua cupidatat officia deserunt.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec31b90929f11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Grilled Quadruple Sandwich",
-        "description": "Ut esse ex cillum voluptate deserunt dolor fugiat eiusmod dolor.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec34b40c20fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Devour",
-      "description": "Nulla pariatur do irure veniam sunt."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "7:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Skywalker's Flesh & Turkey",
-    "address": "603 Powers Street, Chicago, IL, 60655",
-    "coords": [
-      -87.652031,
-      41.89079
-    ],
-    "phone": "+1 (983) 565-2750",
-    "website": "www.rockyard.com",
-    "price": 0,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
-    "burgers": [
-      {
-        "name": "The Sensational Smeared Burger",
-        "description": "Elit Lorem tempor ipsum culpa enim enim excepteur aliquip amet.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e034b70c21f31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Scrumtrulesant Double Sandwich",
-        "description": "Aute ex occaecat tempor ad proident aliqua qui consequat elit duis non.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e030b00721f21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delicious Eat",
-      "description": "Amet eu fugiat culpa deserunt magna commodo excepteur amet."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Sandwiches",
-    "address": "820 Perry Place, Chicago, IL, 60609",
-    "coords": [
-      -87.667079,
-      41.835634
-    ],
-    "phone": "+1 (885) 406-3146",
-    "website": "www.papricut.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
-    "burgers": [
-      {
-        "name": "The Grilled Triple Sandwich",
-        "description": "Est exercitation est deserunt reprehenderit quis est nisi amet do nostrud voluptate anim.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed32b70629f21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delicious Chew",
-      "description": "Amet cupidatat excepteur laborum reprehenderit ad sint."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Old Ben's Bar",
-    "address": "841 Hendrickson Street, Chicago, IL, 60625",
-    "coords": [
-      -87.701236,
-      41.929987
-    ],
-    "phone": "+1 (849) 488-3600",
-    "website": "www.zork.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
-    "burgers": [
-      {
-        "name": "The Yummy Double Sandwich",
-        "description": "Et amet ea mollit ipsum et.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed35b30c2bf51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delightful Double Sandwich",
-        "description": "Exercitation ea aliquip et veniam eu velit commodo culpa voluptate do aliquip voluptate.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb7072cf21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delectable Greasy Burger",
-        "description": "Exercitation pariatur culpa culpa dolore fugiat sint.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e03db70821fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Eat",
-      "description": "Esse sunt ut sint laborum veniam aliqua ut."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Sue's Cantina",
-    "address": "904 Brightwater Court, Chicago, IL, 60624",
-    "coords": [
-      -87.71919,
-      41.844764
-    ],
-    "phone": "+1 (965) 410-3313",
-    "website": "www.quarx.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
-    "burgers": [
-      {
-        "name": "The Enticing Quadruple Sandwich",
-        "description": "Et laboris mollit excepteur dolore culpa ad dolor.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13db8062bf41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Jedi Master Quadruple Sandwich",
-        "description": "Occaecat elit est officia qui cillum aliqua veniam.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e03cb70f2bf31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Devour",
-      "description": "Elit amet dolore dolor commodo et sint do ea."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "10:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Pub",
-    "address": "788 Albany Avenue, Chicago, IL, 60623",
-    "coords": [
-      -87.683609,
-      41.914556
-    ],
-    "phone": "+1 (983) 418-3129",
-    "website": "www.terrasys.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
-    "burgers": [
-      {
-        "name": "The King Kong Greasy Burger",
-        "description": "Do adipisicing ullamco labore commodo cillum nulla qui in id elit.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ee35b3062bf11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Enticing Devour",
-      "description": "Velit velit labore minim eu tempor labore minim officia eiusmod tempor."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
+      "opening": "11:00AM",
       "closing": "12:00PM",
       "closed": false
     }
   },
   {
-    "name": "Old Ben's Buffet",
-    "address": "843 Bouck Court, Chicago, IL, 60642",
+    "name": "Bowsers Between the Bunz",
+    "address": "879 Malta Street, Chicago, IL, 60640",
     "coords": [
-      -87.647356,
-      41.850555
+      -87.721369,
+      41.831206
     ],
-    "phone": "+1 (908) 425-3811",
-    "website": "www.irack.com",
-    "price": 0,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
-    "burgers": [
-      {
-        "name": "The Turbo Smeared Burger",
-        "description": "Id sunt nisi minim elit id mollit minim Lorem exercitation.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13db8062bf41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Filling Triple Burger",
-        "description": "Ea cillum ad sint proident.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec33b10b2df31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Yummy Double Burger",
-        "description": "Irure sint sit tempor et Lorem dolore incididunt in est dolor id Lorem cupidatat.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e137b60c28fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Devour",
-      "description": "Eu qui mollit laboris fugiat aute ut pariatur velit ea."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "6:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Sue's Fusion",
-    "address": "463 Seton Place, Chicago, IL, 60612",
-    "coords": [
-      -87.710456,
-      41.87144
-    ],
-    "phone": "+1 (989) 426-2096",
-    "website": "www.imageflow.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
-    "burgers": [
-      {
-        "name": "The Sensational Double Sandwich",
-        "description": "Do dolore exercitation ea laboris do minim incididunt incididunt voluptate.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e834b00821f01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Eat",
-      "description": "Elit quis minim officia ex non cillum sunt dolor irure fugiat qui."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "7:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Lounge",
-    "address": "191 Grattan Street, Chicago, IL, 60603",
-    "coords": [
-      -87.720933,
-      41.883937
-    ],
-    "phone": "+1 (831) 490-3967",
-    "website": "www.mixers.com",
-    "price": 0,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
-    "burgers": [
-      {
-        "name": "The Sensational Triple Sandwich",
-        "description": "Incididunt laboris officia fugiat cupidatat cillum in id duis mollit reprehenderit dolor.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ed33b3072bf51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Turbo Smeared Sandwich",
-        "description": "Id laborum aliqua minim ipsum adipisicing qui.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e137b60c28fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Eat",
-      "description": "Quis cupidatat aliqua excepteur consectetur irure excepteur nostrud minim adipisicing ad cupidatat."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bacon Between the Bunz",
-    "address": "989 Maple Avenue, Chicago, IL, 60626",
-    "coords": [
-      -87.682367,
-      41.93053
-    ],
-    "phone": "+1 (877) 565-2755",
-    "website": "www.pharmacon.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
-    "burgers": [
-      {
-        "name": "The Meaty Greasy Sandwich",
-        "description": "Laboris aliquip enim occaecat amet ea labore ullamco consectetur est qui qui ex commodo laboris.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e03db70821fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Turbo Double Burger",
-        "description": "Nisi labore consequat ullamco elit fugiat elit irure ullamco.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e137b2082af51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delectable Graze",
-      "description": "Incididunt aliquip laborum commodo excepteur sit nulla do minim exercitation."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Sandwiches",
-    "address": "538 Monitor Street, Chicago, IL, 60636",
-    "coords": [
-      -87.662262,
-      41.862198
-    ],
-    "phone": "+1 (800) 476-2062",
-    "website": "www.junipoor.com",
-    "price": 4,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
-    "burgers": [
-      {
-        "name": "The Meaty Quadruple Sandwich",
-        "description": "Irure labore mollit tempor consectetur laboris tempor commodo.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e834b00821f01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Chew",
-      "description": "Dolor qui commodo culpa irure consectetur eu reprehenderit esse."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Café",
-    "address": "590 Martense Street, Chicago, IL, 60604",
-    "coords": [
-      -87.692108,
-      41.871986
-    ],
-    "phone": "+1 (872) 419-2224",
-    "website": "www.bisba.com",
-    "price": 0,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
-    "burgers": [
-      {
-        "name": "The Grilled Smeared Sandwich",
-        "description": "Occaecat magna dolore eiusmod aliquip fugiat culpa nulla consectetur sunt.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec3cb50b2efc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Yummy Greasy Sandwich",
-        "description": "Lorem do voluptate cillum mollit eiusmod laborum ipsum.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb7072bfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Enticing Chew",
-      "description": "Do aliqua consectetur mollit sit sunt sunt pariatur cillum."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Bar",
-    "address": "377 Dictum Court, Chicago, IL, 60706",
-    "coords": [
-      -87.704281,
-      41.930975
-    ],
-    "phone": "+1 (871) 497-3292",
-    "website": "www.genekom.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delightful Quadruple Burger",
-        "description": "Ipsum laboris culpa sunt esse dolore nisi exercitation elit magna amet.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e132b30b2cfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Eat",
-      "description": "Sit adipisicing eiusmod aliqua nulla enim officia eu occaecat esse dolore dolore."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bowsers Sandwiches",
-    "address": "469 Harman Street, Chicago, IL, 60649",
-    "coords": [
-      -87.713624,
-      41.93039
-    ],
-    "phone": "+1 (818) 580-3726",
-    "website": "www.phuel.com",
-    "price": 0,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
-    "burgers": [
-      {
-        "name": "The Grilled Cheesy Sandwich",
-        "description": "Dolore sit anim eu exercitation enim laborum fugiat velit.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ea36b20b2af31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delectable Triple Burger",
-        "description": "Sint laboris eu ipsum sint nisi sunt reprehenderit non.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e03db6092cf01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Graze",
-      "description": "Aute elit eiusmod deserunt eu velit labore dolore consectetur id."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "10:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Old Ben's Fusion",
-    "address": "998 Berry Street, Chicago, IL, 60647",
-    "coords": [
-      -87.641433,
-      41.89034
-    ],
-    "phone": "+1 (962) 571-3292",
-    "website": "www.suremax.com",
-    "price": 1,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
-    "burgers": [
-      {
-        "name": "The Enticing Double Burger",
-        "description": "Velit labore enim fugiat elit ad.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e03db70821fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Yummy Quadruple Sandwich",
-        "description": "Laborum consequat pariatur ipsum proident in ut ullamco irure.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13cb30c20fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Eat",
-      "description": "Laboris proident incididunt elit tempor officia qui occaecat esse mollit in consequat aliqua eiusmod qui."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet BBQ",
-    "address": "711 President Street, Chicago, IL, 60651",
-    "coords": [
-      -87.644437,
-      41.894242
-    ],
-    "phone": "+1 (897) 401-2064",
-    "website": "www.uneeq.com",
-    "price": 1,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
-    "burgers": [
-      {
-        "name": "The Grilled Double Sandwich",
-        "description": "Lorem Lorem ullamco exercitation mollit esse.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e137b2082af51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delightful Smeared Burger",
-        "description": "Nulla ipsum exercitation sit commodo ex irure minim.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec35b10f2df01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Jedi Master Smeared Sandwich",
-        "description": "Laborum ullamco cupidatat minim consectetur veniam tempor irure laborum cillum tempor velit officia.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ed31b40a20f51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Heavenly Devour",
-      "description": "Occaecat magna cupidatat fugiat sint cillum mollit cillum consequat sunt nulla cillum pariatur sint."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Old Ben's Fusion",
-    "address": "659 Irvington Place, Chicago, IL, 60646",
-    "coords": [
-      -87.7335,
-      41.913871
-    ],
-    "phone": "+1 (841) 544-2565",
-    "website": "www.cosmosis.com",
-    "price": 1,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
-    "burgers": [
-      {
-        "name": "The Heavenly Cheesy Burger",
-        "description": "Ex non reprehenderit consectetur occaecat minim nulla magna.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec32b50c2cf01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delightful Quadruple Sandwich",
-        "description": "Do eiusmod velit magna adipisicing.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13cb5082af01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delectable Eat",
-      "description": "Sint aliquip anim tempor aliquip occaecat deserunt dolor sint reprehenderit laboris esse qui aute."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Organic BBQ",
-    "address": "429 Strong Place, Chicago, IL, 60657",
-    "coords": [
-      -87.648233,
-      41.870914
-    ],
-    "phone": "+1 (954) 411-3017",
-    "website": "www.quizmo.com",
-    "price": 1,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
-    "burgers": [
-      {
-        "name": "The Thick Quadruple Burger",
-        "description": "Magna dolor consequat ad sit proident exercitation fugiat dolor sint aliquip dolor occaecat pariatur laborum.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ef32b60f2df71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Heavenly Cheesy Burger",
-        "description": "Enim non dolor sint excepteur ex id ea non sit aliquip.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e133b90e2cf11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Jedi Master Cheesy Sandwich",
-        "description": "Deserunt duis officia nisi nulla laborum est ullamco fugiat occaecat ad Lorem dolor exercitation.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec3db80f28f01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Eat",
-      "description": "Exercitation non aliqua ipsum quis minim elit."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bacon Between the Bunz",
-    "address": "192 Oriental Boulevard, Chicago, IL, 60609",
-    "coords": [
-      -87.65808,
-      41.833648
-    ],
-    "phone": "+1 (910) 512-3378",
-    "website": "www.zoid.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
-    "burgers": [
-      {
-        "name": "The Heavenly Triple Burger",
-        "description": "Magna qui dolore amet incididunt.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb7072bfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delicious Eat",
-      "description": "Voluptate duis aliquip ut veniam et sit fugiat elit culpa cillum et."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Sue's Buffet",
-    "address": "646 Hemlock Street, Chicago, IL, 60655",
-    "coords": [
-      -87.670145,
-      41.857019
-    ],
-    "phone": "+1 (875) 581-2934",
-    "website": "www.bedlam.com",
+    "phone": "+1 (961) 447-3390",
+    "website": "www.spherix.com",
     "price": 3,
     "foodtruck": false,
     "veggie": false,
-    "byob": false,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
-    "burgers": [
-      {
-        "name": "The Turbo Triple Sandwich",
-        "description": "Magna eiusmod incididunt non et consectetur sunt excepteur deserunt eu consequat irure esse do.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ea30b40c2cf61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Heavenly Double Burger",
-        "description": "Laboris ad deserunt excepteur consequat tempor occaecat est dolore velit proident ipsum culpa.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ed36b90d2af71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Turbo Cheesy Burger",
-        "description": "Reprehenderit esse laborum nostrud deserunt id culpa eiusmod sit amet ex incididunt.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e03db60d2df11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Eat",
-      "description": "Fugiat elit occaecat occaecat sunt officia duis id eu occaecat consectetur occaecat qui velit."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Skywalker's Pub",
-    "address": "446 Lorraine Street, Chicago, IL, 60609",
-    "coords": [
-      -87.690573,
-      41.924804
-    ],
-    "phone": "+1 (824) 535-2973",
-    "website": "www.quotezart.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
-    "burgers": [
-      {
-        "name": "The Enticing Quadruple Sandwich",
-        "description": "Do cillum ut nulla nostrud.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e134b20b28f31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delectable Smeared Sandwich",
-        "description": "Enim ut aliquip veniam id pariatur exercitation elit do amet culpa et.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee31b60b20e90825d0471404e14f4195e075ffd41db4134395f2c27ba2_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delicious Chew",
-      "description": "Labore officia est elit Lorem mollit esse ipsum mollit sint nostrud pariatur ipsum fugiat ullamco."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "7:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Tom's Sandwiches",
-    "address": "704 Hancock Street, Chicago, IL, 60630",
-    "coords": [
-      -87.733902,
-      41.844453
-    ],
-    "phone": "+1 (973) 503-3618",
-    "website": "www.imkan.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": true,
     "byob": true,
     "alcohol": false,
     "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delightful Greasy Burger",
-        "description": "Qui mollit adipisicing aliqua laborum.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb7072cf21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Yummy Quadruple Sandwich",
-        "description": "Excepteur mollit incididunt magna eiusmod esse id.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb7072cf21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Scrumtrulesant Double Sandwich",
-        "description": "Duis aute consequat nostrud reprehenderit velit magna sit enim sunt et minim ut.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e835b90e2ff4063ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delectable Chew",
-      "description": "Nostrud voluptate velit sint cillum ex duis culpa."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Turbo Bar",
-    "address": "851 Melba Court, Chicago, IL, 60603",
-    "coords": [
-      -87.684479,
-      41.854063
-    ],
-    "phone": "+1 (924) 403-3819",
-    "website": "www.keengen.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delightful Double Sandwich",
-        "description": "Mollit sint ad labore anim.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec34b40c20fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Enticing Graze",
-      "description": "Proident adipisicing veniam eiusmod enim ad et adipisicing labore commodo eiusmod magna mollit."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "10:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Tavern",
-    "address": "596 Grant Avenue, Chicago, IL, 60644",
-    "coords": [
-      -87.643928,
-      41.895901
-    ],
-    "phone": "+1 (941) 420-3476",
-    "website": "www.perkle.com",
-    "price": 1,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delectable Double Burger",
-        "description": "Deserunt fugiat excepteur pariatur et incididunt non duis consequat adipisicing ad reprehenderit dolore exercitation irure.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed36b90d2af71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Filling Double Burger",
-        "description": "Mollit enim qui eiusmod dolor do cillum nisi dolore sit amet consectetur nisi.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ea30b10f21f51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Thick Greasy Sandwich",
-        "description": "Consequat fugiat commodo mollit et veniam magna fugiat nostrud cupidatat ut excepteur nisi.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb7072cf61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Enticing Graze",
-      "description": "Qui nisi consectetur elit excepteur quis anim qui et duis officia culpa sit aute fugiat."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "6:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bacon Chophouse",
-    "address": "645 Wogan Terrace, Chicago, IL, 60619",
-    "coords": [
-      -87.642341,
-      41.869526
-    ],
-    "phone": "+1 (922) 416-3912",
-    "website": "www.bizmatic.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
     "outdoor": true,
     "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
     "burgers": [
       {
-        "name": "The Yummy Cheesy Sandwich",
-        "description": "Cupidatat proident esse nulla consequat exercitation laborum ex est esse.",
-        "rating": 2,
+        "name": "The Grilled Greasy Burger",
+        "description": "Sunt non esse consequat irure adipisicing est elit nostrud reprehenderit anim occaecat dolor excepteur.",
+        "rating": 4,
         "veggie": true,
-        "image": "https://pixabay.com/get/ec36b5092df21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": false,
-          "bison": true,
+          "bison": false,
           "angus": false,
           "turkey": false,
-          "lamb": false,
+          "lamb": true,
           "elk": true
         }
       },
       {
-        "name": "The Sensational Triple Sandwich",
-        "description": "Culpa enim reprehenderit fugiat nisi id dolor sint.",
+        "name": "The Heavenly Greasy Burger",
+        "description": "Eu deserunt tempor do laboris nulla nulla deserunt ipsum qui.",
         "rating": 4,
         "veggie": true,
-        "image": "https://pixabay.com/get/e031b5082af31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
         "meat": {
-          "grassfed": false,
+          "grassfed": true,
           "kobe": true,
           "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Devour",
-      "description": "Mollit amet est laboris id enim dolor aliquip officia."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Tom's Flesh & Turkey",
-    "address": "654 Union Street, Chicago, IL, 60632",
-    "coords": [
-      -87.708611,
-      41.922999
-    ],
-    "phone": "+1 (908) 448-3771",
-    "website": "www.retrack.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
-    "burgers": [
-      {
-        "name": "The Meaty Quadruple Sandwich",
-        "description": "Eiusmod quis labore culpa dolor ipsum laboris deserunt labore nulla.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e031b5082af31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delectable Cheesy Sandwich",
-        "description": "Ullamco commodo qui esse eiusmod eiusmod ut elit nulla sunt pariatur adipisicing adipisicing laboris officia.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ef3db80f2bf21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Chew",
-      "description": "Magna est officia esse cupidatat non."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Lounge",
-    "address": "116 Hastings Street, Chicago, IL, 60605",
-    "coords": [
-      -87.635896,
-      41.849325
-    ],
-    "phone": "+1 (926) 422-2877",
-    "website": "www.baluba.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
-    "burgers": [
-      {
-        "name": "The Meaty Triple Sandwich",
-        "description": "Lorem esse exercitation proident aute est dolor.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e137b60c28fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
           "angus": true,
-          "turkey": true,
+          "turkey": false,
           "lamb": true,
           "elk": false
         }
       }
     ],
     "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Enticing Graze",
-      "description": "Enim in fugiat non anim."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Skywalker's Bar",
-    "address": "140 Schenck Court, Chicago, IL, 60605",
-    "coords": [
-      -87.659606,
-      41.924323
-    ],
-    "phone": "+1 (968) 512-3800",
-    "website": "www.accupharm.com",
-    "price": 3,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
-    "burgers": [
-      {
-        "name": "The Turbo Triple Burger",
-        "description": "Consectetur enim cupidatat veniam sunt anim sit ipsum aliquip irure in laboris labore aute.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec37b60c21f71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
       "grassfed": false,
-      "kobe": true,
+      "kobe": false,
       "bison": true,
-      "angus": true,
+      "angus": false,
       "turkey": false,
-      "lamb": false,
+      "lamb": true,
       "elk": true
     },
     "sides": {
       "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delectable Chew",
-      "description": "Adipisicing in ex aliqua cillum ex eu mollit enim ipsum proident veniam."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bacon Fusion",
-    "address": "238 Preston Court, Chicago, IL, 60608",
-    "coords": [
-      -87.731147,
-      41.91535
-    ],
-    "phone": "+1 (869) 411-3859",
-    "website": "www.tripsch.com",
-    "price": 0,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delicious Quadruple Sandwich",
-        "description": "Adipisicing tempor laboris aliquip velit exercitation voluptate do ad.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e037b60828f31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
       "tots": false,
-      "macAndCheese": false
+      "macAndCheese": true
     },
     "allergies": {
       "accommodates": false,
@@ -3715,2553 +1673,43 @@
     },
     "challenges": {
       "exists": false,
-      "name": "The Meaty Eat",
-      "description": "Non id officia irure ex veniam esse minim nulla deserunt laborum ullamco minim dolor."
+      "name": "The Meaty Devour",
+      "description": "Id id ad culpa laborum."
     },
     "hours": {
       "days": "Monday - Sunday",
       "opening": "11:00AM",
-      "closing": "10:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Café",
-    "address": "525 Turner Place, Chicago, IL, 60639",
-    "coords": [
-      -87.734093,
-      41.921339
-    ],
-    "phone": "+1 (995) 441-2047",
-    "website": "www.printspan.com",
-    "price": 0,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
-    "burgers": [
-      {
-        "name": "The Meaty Triple Burger",
-        "description": "Elit cillum irure adipisicing ut aliquip ex amet veniam in consectetur non ullamco ipsum esse.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee37b10f2cfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Jedi Master Greasy Sandwich",
-        "description": "Exercitation labore sint exercitation labore officia aliquip commodo velit enim esse magna.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e835b90e2ff4063ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delectable Cheesy Burger",
-        "description": "Irure veniam eiusmod ut aute ea ea veniam pariatur enim dolore proident sunt.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed33b3072bf51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Devour",
-      "description": "Do laboris esse nostrud in sit exercitation nisi aute nulla."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Super Mario's Sandwiches",
-    "address": "307 Maple Street, Chicago, IL, 60642",
-    "coords": [
-      -87.719635,
-      41.848087
-    ],
-    "phone": "+1 (819) 532-2647",
-    "website": "www.extragen.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
-    "burgers": [
-      {
-        "name": "The Turbo Triple Burger",
-        "description": "Amet fugiat enim elit esse consectetur Lorem labore voluptate consequat voluptate qui.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec37b30b2ef01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Sensational Double Sandwich",
-        "description": "Dolore consectetur laboris enim officia velit ea nulla.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13cb7072cf21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delicious Double Burger",
-        "description": "Et officia culpa exercitation amet excepteur ad nulla et.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e135b0062cf61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Enticing Eat",
-      "description": "Ex sunt adipisicing sit nisi aliquip et nulla exercitation duis do et excepteur."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Skywalker's Between the Bunz",
-    "address": "986 Troutman Street, Chicago, IL, 60644",
-    "coords": [
-      -87.732766,
-      41.923459
-    ],
-    "phone": "+1 (852) 513-3109",
-    "website": "www.talae.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delicious Quadruple Sandwich",
-        "description": "Reprehenderit nulla laboris tempor occaecat enim eu incididunt elit reprehenderit ullamco.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec37b60c21f71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Heavenly Triple Sandwich",
-        "description": "Exercitation Lorem pariatur do aliquip.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e835b7062cf2023ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delicious Chew",
-      "description": "Duis ad voluptate do duis officia est."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "6:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Tavern",
-    "address": "112 Williamsburg Street, Chicago, IL, 60626",
-    "coords": [
-      -87.668912,
-      41.897401
-    ],
-    "phone": "+1 (815) 481-3941",
-    "website": "www.enthaze.com",
-    "price": 1,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
-    "burgers": [
-      {
-        "name": "The Heavenly Quadruple Burger",
-        "description": "Quis proident dolor aliqua dolore anim cillum proident aute exercitation.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec3db80f28f01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Meaty Quadruple Burger",
-        "description": "Exercitation ea commodo minim enim cillum officia deserunt commodo nulla fugiat.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ea36b20e2cf41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Chew",
-      "description": "Esse quis minim occaecat in minim exercitation tempor dolor mollit commodo labore eu sint veniam."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "10:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Chophouse",
-    "address": "867 Cypress Court, Chicago, IL, 60636",
-    "coords": [
-      -87.703931,
-      41.871297
-    ],
-    "phone": "+1 (841) 466-2548",
-    "website": "www.rockabye.com",
-    "price": 3,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
-    "burgers": [
-      {
-        "name": "The Turbo Smeared Sandwich",
-        "description": "Esse tempor exercitation in minim nulla aliquip eu proident velit qui.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ed35b30c2bf51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Sensational Smeared Sandwich",
-        "description": "Tempor et officia tempor aliqua eu ad pariatur qui sit nostrud officia sit ullamco.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e030b00721f21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Sensational Smeared Sandwich",
-        "description": "Exercitation ullamco ullamco est aute tempor tempor.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec31b90929f11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Eat",
-      "description": "Ex occaecat cillum deserunt nisi culpa fugiat ex amet excepteur enim eiusmod ullamco irure voluptate."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bowsers Burgers",
-    "address": "229 Highland Boulevard, Chicago, IL, 60607",
-    "coords": [
-      -87.652564,
-      41.853778
-    ],
-    "phone": "+1 (892) 458-3719",
-    "website": "www.momentia.com",
-    "price": 1,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
-    "burgers": [
-      {
-        "name": "The Meaty Triple Sandwich",
-        "description": "Laboris adipisicing occaecat incididunt aute amet.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e137b60c28fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Thick Quadruple Burger",
-        "description": "Pariatur mollit in excepteur ullamco id adipisicing ea ut officia Lorem.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec34b40c20fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The King Kong Double Sandwich",
-        "description": "Aute laborum mollit Lorem nostrud est sint incididunt laboris quis laboris veniam duis culpa laboris.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed31b40a20f51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delicious Devour",
-      "description": "Minim ut consectetur ut cillum minim cillum amet."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
       "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Bistro",
-    "address": "687 Roosevelt Place, Chicago, IL, 60615",
-    "coords": [
-      -87.730027,
-      41.914235
-    ],
-    "phone": "+1 (844) 425-2514",
-    "website": "www.mantro.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
-    "burgers": [
-      {
-        "name": "The Filling Greasy Burger",
-        "description": "Et eu occaecat sit qui mollit laboris sunt ex.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec31b10d2bf11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Turbo Cheesy Sandwich",
-        "description": "Reprehenderit aute veniam magna esse consequat.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ea33b30f2cf61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Devour",
-      "description": "Quis in non commodo ullamco ad quis officia."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "7:00PM",
       "closed": false
     }
   },
   {
     "name": "Sue's Flesh & Turkey",
-    "address": "389 Lott Avenue, Chicago, IL, 60603",
+    "address": "773 Lancaster Avenue, Chicago, IL, 60707",
     "coords": [
-      -87.690649,
-      41.929472
+      -87.694708,
+      41.858567
     ],
-    "phone": "+1 (827) 456-3468",
-    "website": "www.digitalus.com",
-    "price": 0,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
-    "burgers": [
-      {
-        "name": "The Grilled Double Burger",
-        "description": "Officia velit commodo labore velit amet laborum occaecat qui culpa duis irure exercitation amet qui.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13db2072df21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Turbo Quadruple Sandwich",
-        "description": "Laboris labore nisi ad aliqua et aute minim elit exercitation exercitation do id proident tempor.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ef36b30b2cf31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Graze",
-      "description": "Aliqua irure ut ullamco anim aliquip ut mollit."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Lounge",
-    "address": "733 Crown Street, Chicago, IL, 60636",
-    "coords": [
-      -87.637674,
-      41.877342
-    ],
-    "phone": "+1 (984) 438-3699",
-    "website": "www.amtap.com",
-    "price": 3,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
-    "burgers": [
-      {
-        "name": "The Enticing Greasy Sandwich",
-        "description": "Ut est qui aliqua culpa sunt in qui commodo sint do laboris nostrud.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ed31b40a20f51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delicious Quadruple Sandwich",
-        "description": "Mollit eiusmod labore ad adipisicing aliquip magna sunt ut.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e132b50e2cf71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Meaty Eat",
-      "description": "Aliquip sint nisi sit quis deserunt officia amet incididunt pariatur."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Bistro",
-    "address": "854 Frank Court, Chicago, IL, 60636",
-    "coords": [
-      -87.646869,
-      41.867428
-    ],
-    "phone": "+1 (889) 484-2141",
-    "website": "www.exoplode.com",
-    "price": 0,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
-    "burgers": [
-      {
-        "name": "The Filling Double Sandwich",
-        "description": "Velit aliquip consectetur et eu ea non commodo esse dolor irure qui magna.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e132b50828f71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delicious Cheesy Sandwich",
-        "description": "Duis sit culpa eu sunt excepteur occaecat proident occaecat non ullamco pariatur.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e132b50e2cf71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Scrumtrulesant Greasy Burger",
-        "description": "Duis quis ex nulla deserunt et pariatur velit id culpa eiusmod pariatur elit sit.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13db8062bf41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delicious Eat",
-      "description": "Qui irure mollit consequat enim eu fugiat."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Buffet",
-    "address": "256 Cook Street, Chicago, IL, 60655",
-    "coords": [
-      -87.658251,
-      41.911107
-    ],
-    "phone": "+1 (996) 481-2666",
-    "website": "www.ontality.com",
-    "price": 3,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
-    "burgers": [
-      {
-        "name": "The Scrum-dilly-omcious Triple Sandwich",
-        "description": "Reprehenderit consequat ex qui culpa do.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e031b60721fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Thick Double Burger",
-        "description": "Mollit elit magna labore cillum consectetur proident in minim officia ut nisi commodo.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e835b7062cf2023ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The King Kong Cheesy Sandwich",
-        "description": "Laboris Lorem exercitation laboris ullamco laborum incididunt consequat culpa fugiat ullamco deserunt consequat.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e834b00821f01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": true,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delicious Chew",
-      "description": "Deserunt mollit laborum enim et labore est."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Tom's Fusion",
-    "address": "261 Kimball Street, Chicago, IL, 60603",
-    "coords": [
-      -87.73238,
-      41.862267
-    ],
-    "phone": "+1 (984) 439-3322",
-    "website": "www.besto.com",
-    "price": 0,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
-    "burgers": [
-      {
-        "name": "The Heavenly Double Sandwich",
-        "description": "Nisi consequat aute enim enim reprehenderit nulla enim proident reprehenderit aliqua.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb7072bfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Heavenly Smeared Burger",
-        "description": "Exercitation enim labore cupidatat sint in quis fugiat ut anim labore ex non commodo.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e031b40c2af51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Graze",
-      "description": "Labore consectetur dolore veniam velit enim commodo nostrud mollit adipisicing amet."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Old Ben's Bar",
-    "address": "760 Empire Boulevard, Chicago, IL, 60176",
-    "coords": [
-      -87.705238,
-      41.840308
-    ],
-    "phone": "+1 (888) 578-3373",
-    "website": "www.barkarama.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delightful Smeared Burger",
-        "description": "Ullamco est id ullamco ad labore voluptate irure cillum laborum eu ea reprehenderit sint.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/eb35b60d21f11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Turbo Greasy Burger",
-        "description": "Proident est labore proident sunt ad sunt ea quis dolore in ut labore.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec37b30b2ef01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Graze",
-      "description": "Dolore aliqua ut sunt eu sint anim incididunt elit magna quis eu magna mollit consectetur."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Super Mario's BBQ",
-    "address": "103 Olive Street, Chicago, IL, 60645",
-    "coords": [
-      -87.646419,
-      41.885075
-    ],
-    "phone": "+1 (922) 483-2776",
-    "website": "www.geeketron.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delightful Quadruple Sandwich",
-        "description": "In ipsum voluptate elit nulla eu consectetur reprehenderit non nisi excepteur minim enim officia consequat.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ed33b3072bf51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Turbo Double Sandwich",
-        "description": "Et ut ex magna in eu consectetur sit eiusmod fugiat.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec34b40c20fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Grilled Smeared Burger",
-        "description": "Dolore enim commodo elit Lorem elit laborum.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ea30b50f2efd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Eat",
-      "description": "Exercitation id qui irure consectetur proident ut enim."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Pub",
-    "address": "406 Monroe Place, Chicago, IL, 60624",
-    "coords": [
-      -87.667129,
-      41.863339
-    ],
-    "phone": "+1 (904) 443-2261",
-    "website": "www.pasturia.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
-    "burgers": [
-      {
-        "name": "The Meaty Double Burger",
-        "description": "Id nulla veniam in excepteur.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13db2072df21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Scrumtrulesant Greasy Burger",
-        "description": "Qui in ex mollit veniam nulla ex ipsum.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec35b10f2df01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Enticing Quadruple Burger",
-        "description": "Non veniam est ullamco Lorem.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ee35b3062bf11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delicious Eat",
-      "description": "Exercitation non anim laboris ipsum officia eiusmod voluptate labore sint do nisi mollit cillum."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Bar",
-    "address": "334 Howard Alley, Chicago, IL, 60621",
-    "coords": [
-      -87.679404,
-      41.833732
-    ],
-    "phone": "+1 (815) 580-3917",
-    "website": "www.comverges.com",
-    "price": 1,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
-    "burgers": [
-      {
-        "name": "The Enticing Quadruple Burger",
-        "description": "Nulla occaecat sunt dolor laboris commodo sit ex aute dolore enim sint minim.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed32b70629f21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Heavenly Devour",
-      "description": "Sint sit sunt exercitation veniam dolore laboris pariatur et."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Chophouse",
-    "address": "473 Poly Place, Chicago, IL, 60655",
-    "coords": [
-      -87.68692,
-      41.919649
-    ],
-    "phone": "+1 (930) 599-3015",
-    "website": "www.pathways.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
-    "burgers": [
-      {
-        "name": "The Heavenly Smeared Burger",
-        "description": "Esse deserunt amet dolor ex sit voluptate.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ef3db90d2bf11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Turbo Quadruple Burger",
-        "description": "Adipisicing aliquip ad aliquip cillum magna ullamco minim in exercitation.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ee33b1072ff71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delicious Graze",
-      "description": "Ex nostrud ut ad Lorem culpa proident duis."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bacon Chophouse",
-    "address": "637 Tillary Street, Chicago, IL, 60606",
-    "coords": [
-      -87.680972,
-      41.874223
-    ],
-    "phone": "+1 (950) 497-3225",
-    "website": "www.exerta.com",
-    "price": 1,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
-    "burgers": [
-      {
-        "name": "The Scrum-dilly-omcious Quadruple Burger",
-        "description": "Reprehenderit enim voluptate mollit irure do excepteur laboris consectetur laboris amet nostrud.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13cb30c20fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delicious Devour",
-      "description": "Qui consectetur cupidatat eiusmod amet."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Flesh & Turkey",
-    "address": "381 Clifford Place, Chicago, IL, 60620",
-    "coords": [
-      -87.726533,
-      41.914987
-    ],
-    "phone": "+1 (926) 430-2721",
-    "website": "www.waab.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delightful Quadruple Burger",
-        "description": "Enim Lorem amet nisi sunt adipisicing ut irure adipisicing aute excepteur dolore eiusmod id.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e132b30b2cfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Turbo Triple Sandwich",
-        "description": "Deserunt amet sunt amet labore ea est duis irure ipsum deserunt.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13cb7072cf61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delicious Eat",
-      "description": "Amet Lorem laborum ex consequat est cillum."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "6:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bacon Tavern",
-    "address": "511 Reeve Place, Chicago, IL, 60631",
-    "coords": [
-      -87.677127,
-      41.862689
-    ],
-    "phone": "+1 (994) 514-2010",
+    "phone": "+1 (855) 572-3484",
     "website": "www.visalia.com",
     "price": 3,
     "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
-    "burgers": [
-      {
-        "name": "The Yummy Quadruple Burger",
-        "description": "Id quis et non nulla eu duis nostrud magna velit exercitation.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec33b10b2df31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Meaty Smeared Burger",
-        "description": "Laboris in velit dolor aliqua id.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e132b50828f71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Chew",
-      "description": "Excepteur laborum ipsum ut sint enim reprehenderit laborum nisi sunt excepteur laborum ad eu incididunt."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Super Mario's Chophouse",
-    "address": "428 Bedford Place, Chicago, IL, 60634",
-    "coords": [
-      -87.636931,
-      41.851187
-    ],
-    "phone": "+1 (958) 409-2518",
-    "website": "www.zosis.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
-    "burgers": [
-      {
-        "name": "The Jedi Master Greasy Burger",
-        "description": "Magna duis ex qui anim qui magna.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ea30b40c2cf61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Scrumtrulesant Triple Burger",
-        "description": "Commodo occaecat Lorem commodo est laboris proident.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e131b4082df41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Heavenly Chew",
-      "description": "Eiusmod esse ipsum commodo ipsum consectetur eu."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "7:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Super Mario's Bar",
-    "address": "927 Louisa Street, Chicago, IL, 60605",
-    "coords": [
-      -87.635992,
-      41.900397
-    ],
-    "phone": "+1 (806) 495-3648",
-    "website": "www.ramjob.com",
-    "price": 4,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
-    "burgers": [
-      {
-        "name": "The Yummy Cheesy Sandwich",
-        "description": "Nostrud ut sint id labore non labore magna elit et dolore et veniam in.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec36b5092df21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Chew",
-      "description": "Consectetur laborum eiusmod proident incididunt aliquip nisi aliqua duis sint laborum in id do."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bowsers Flesh & Turkey",
-    "address": "445 Dewitt Avenue, Chicago, IL, 60645",
-    "coords": [
-      -87.684165,
-      41.892396
-    ],
-    "phone": "+1 (939) 475-3478",
-    "website": "www.gallaxia.com",
-    "price": 0,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
-    "burgers": [
-      {
-        "name": "The King Kong Smeared Sandwich",
-        "description": "Ipsum amet et eu reprehenderit reprehenderit commodo aute aliqua laborum laboris nostrud.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ee3db20a2df51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Heavenly Cheesy Burger",
-        "description": "Ut culpa velit enim nulla sint sit aliquip.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec37b30b2ef01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Graze",
-      "description": "Culpa qui voluptate sunt do commodo anim labore irure elit anim magna fugiat et."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Organic Pub",
-    "address": "478 Hope Street, Chicago, IL, 60642",
-    "coords": [
-      -87.674275,
-      41.848848
-    ],
-    "phone": "+1 (944) 472-2343",
-    "website": "www.renovize.com",
-    "price": 1,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
-    "burgers": [
-      {
-        "name": "The Thick Triple Burger",
-        "description": "Cillum consectetur commodo labore excepteur eu labore culpa fugiat laborum eu fugiat.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e032b40920fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Enticing Greasy Burger",
-        "description": "Ad dolor est Lorem ullamco consequat nisi nulla deserunt.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec37b60c21f71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Filling Quadruple Burger",
-        "description": "Pariatur in Lorem non tempor mollit laborum irure.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e834b1062dfc063ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delectable Chew",
-      "description": "Ad enim ullamco ea exercitation fugiat voluptate aliqua anim quis velit."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Old Ben's Café",
-    "address": "610 Miller Avenue, Chicago, IL, 60649",
-    "coords": [
-      -87.729892,
-      41.863833
-    ],
-    "phone": "+1 (983) 509-2947",
-    "website": "www.limozen.com",
-    "price": 3,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
-    "burgers": [
-      {
-        "name": "The Turbo Cheesy Sandwich",
-        "description": "Ad elit exercitation consectetur velit dolor laboris culpa anim anim nisi reprehenderit non officia dolore.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e032b40920fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Jedi Master Double Sandwich",
-        "description": "Cupidatat laboris consectetur pariatur ipsum veniam deserunt ad.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e030b60d2af31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Enticing Graze",
-      "description": "Exercitation consequat anim aute consectetur dolore ex do consectetur."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Old Ben's Pub",
-    "address": "316 Schenck Street, Chicago, IL, 60176",
-    "coords": [
-      -87.715822,
-      41.859011
-    ],
-    "phone": "+1 (995) 428-3773",
-    "website": "www.comstar.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delicious Triple Burger",
-        "description": "Incididunt nostrud ullamco nisi non elit do ut amet occaecat nisi cillum ad.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e835b7062cf2023ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Devour",
-      "description": "Et do culpa do eu voluptate irure occaecat aliqua."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "7:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Turbo Burgers",
-    "address": "367 Hanover Place, Chicago, IL, 60644",
-    "coords": [
-      -87.677776,
-      41.841597
-    ],
-    "phone": "+1 (926) 504-3075",
-    "website": "www.dognost.com",
-    "price": 4,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
-    "burgers": [
-      {
-        "name": "The Scrumtrulesant Smeared Sandwich",
-        "description": "Velit pariatur ut sint ipsum pariatur minim officia dolore eu do velit.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e132b50e2cf71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delicious Cheesy Burger",
-        "description": "Ad aliqua in et eiusmod aute.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed36b5092dfc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Jedi Master Greasy Sandwich",
-        "description": "Veniam incididunt fugiat est aliqua culpa magna.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e03cb70f2bf31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Heavenly Graze",
-      "description": "Quis labore eu mollit fugiat consequat adipisicing enim aliqua aliquip in adipisicing."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Turbo Tavern",
-    "address": "192 Gatling Place, Chicago, IL, 60618",
-    "coords": [
-      -87.679757,
-      41.928353
-    ],
-    "phone": "+1 (896) 433-3015",
-    "website": "www.arctiq.com",
-    "price": 1,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
-    "burgers": [
-      {
-        "name": "The Heavenly Double Sandwich",
-        "description": "Dolor duis reprehenderit exercitation occaecat ex deserunt dolor proident voluptate et magna.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ea33b30f2cf61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Turbo Triple Sandwich",
-        "description": "Eiusmod quis voluptate magna reprehenderit nisi laboris do eiusmod in aliquip ut adipisicing deserunt.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e834b1062dfc063ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": false,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Graze",
-      "description": "Dolor proident minim consectetur sunt nisi occaecat non deserunt do anim esse incididunt magna."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Café",
-    "address": "696 Bridge Street, Chicago, IL, 60604",
-    "coords": [
-      -87.667505,
-      41.861036
-    ],
-    "phone": "+1 (975) 478-3756",
-    "website": "www.quonata.com",
-    "price": 1,
-    "foodtruck": true,
     "veggie": false,
     "byob": false,
     "alcohol": false,
     "latenight": false,
     "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
     "burgers": [
       {
-        "name": "The Scrum-dilly-omcious Greasy Burger",
-        "description": "Cillum dolore est in occaecat mollit irure irure magna magna.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee37b9072df11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Filling Double Sandwich",
-        "description": "Commodo laborum elit duis officia.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec32b50c2cf01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delectable Eat",
-      "description": "Irure occaecat consectetur pariatur amet reprehenderit elit."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bacon Lounge",
-    "address": "828 Bowery Street, Chicago, IL, 60642",
-    "coords": [
-      -87.691447,
-      41.830483
-    ],
-    "phone": "+1 (887) 433-3901",
-    "website": "www.niquent.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
-    "burgers": [
-      {
-        "name": "The Scrumtrulesant Double Burger",
-        "description": "Sit et ad enim ullamco voluptate aute.",
+        "name": "The Enticing Triple Burger",
+        "description": "Deserunt sunt sint ad consequat minim elit mollit.",
         "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee30b60a2bfc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
         "meat": {
           "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delectable Chew",
-      "description": "Deserunt in reprehenderit irure ea sit et ea magna velit."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "6:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Pub",
-    "address": "856 Elliott Place, Chicago, IL, 60630",
-    "coords": [
-      -87.665163,
-      41.927067
-    ],
-    "phone": "+1 (990) 521-2636",
-    "website": "www.flexigen.com",
-    "price": 2,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delightful Cheesy Burger",
-        "description": "Qui cupidatat ea tempor eu laboris magna esse do et velit consectetur elit magna.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee34b20b29f41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
+          "kobe": true,
           "bison": false,
           "angus": false,
           "turkey": false,
@@ -6271,43 +1719,156 @@
       },
       {
         "name": "The Scrum-dilly-omcious Smeared Burger",
-        "description": "Qui nulla do veniam ut magna occaecat proident incididunt ad.",
-        "rating": 0,
+        "description": "Deserunt anim veniam dolor labore ipsum Lorem.",
+        "rating": 4,
         "veggie": false,
-        "image": "https://pixabay.com/get/ef33b80d2df61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
         "meat": {
           "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Heavenly Smeared Burger",
+        "description": "Incididunt reprehenderit laboris incididunt excepteur aliquip nostrud eiusmod velit esse veniam consectetur non elit.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delectable Eat",
+      "description": "Ex consequat minim amet cillum aute."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Lounge",
+    "address": "196 Canarsie Road, Chicago, IL, 60653",
+    "coords": [
+      -87.661621,
+      41.855948
+    ],
+    "phone": "+1 (994) 443-2938",
+    "website": "www.corporana.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+    "burgers": [
+      {
+        "name": "The Enticing Greasy Burger",
+        "description": "Dolore quis do aliquip quis ad do anim laborum aliquip amet.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+        "meat": {
+          "grassfed": false,
           "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delicious Smeared Burger",
+        "description": "Excepteur est ullamco occaecat eiusmod est do ut excepteur.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
           "bison": false,
           "angus": true,
           "turkey": false,
           "lamb": true,
           "elk": true
         }
+      },
+      {
+        "name": "The Jedi Master Greasy Burger",
+        "description": "Ipsum in elit nisi duis enim qui.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
       }
     ],
     "meats": {
-      "grassfed": true,
+      "grassfed": false,
       "kobe": true,
       "bison": true,
       "angus": true,
-      "turkey": false,
+      "turkey": true,
       "lamb": false,
-      "elk": true
+      "elk": false
     },
     "sides": {
       "duckFries": false,
-      "tots": true,
+      "tots": false,
       "macAndCheese": true
     },
     "allergies": {
       "accommodates": false,
-      "glutenFree": false
+      "glutenFree": true
     },
     "challenges": {
-      "exists": true,
+      "exists": false,
       "name": "The Yummy Devour",
-      "description": "Id excepteur id officia ut mollit nulla."
+      "description": "Magna veniam deserunt non ut sit eu nostrud mollit."
     },
     "hours": {
       "days": "Monday - Sunday",
@@ -6317,33 +1878,49 @@
     }
   },
   {
-    "name": "Old Ben's Cantina",
-    "address": "279 Osborn Street, Chicago, IL, 60619",
+    "name": "Tom's Sandwiches",
+    "address": "395 Wolf Place, Chicago, IL, 60619",
     "coords": [
-      -87.65896,
-      41.928077
+      -87.734632,
+      41.886779
     ],
-    "phone": "+1 (933) 509-2169",
-    "website": "www.isologica.com",
-    "price": 3,
-    "foodtruck": true,
-    "veggie": false,
+    "phone": "+1 (805) 476-3806",
+    "website": "www.aeora.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
     "byob": true,
     "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
     "burgers": [
       {
-        "name": "The Yummy Greasy Sandwich",
-        "description": "Proident cillum anim sit sit nulla anim.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e137b60c29f41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "name": "The Yummy Triple Sandwich",
+        "description": "Laborum cillum eiusmod excepteur adipisicing do anim in tempor tempor occaecat exercitation et labore duis.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
         "meat": {
-          "grassfed": true,
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Heavenly Cheesy Burger",
+        "description": "Tempor ut consequat commodo non.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+        "meat": {
+          "grassfed": false,
           "kobe": true,
-          "bison": true,
+          "bison": false,
           "angus": true,
           "turkey": false,
           "lamb": true,
@@ -6351,27 +1928,27 @@
         }
       },
       {
-        "name": "The Scrum-dilly-omcious Greasy Burger",
-        "description": "Lorem aliqua voluptate anim tempor voluptate non ut ea amet commodo voluptate ullamco proident incididunt.",
-        "rating": 3,
+        "name": "The Scrum-dilly-omcious Cheesy Burger",
+        "description": "Aute minim dolor occaecat mollit.",
+        "rating": 4,
         "veggie": true,
-        "image": "https://pixabay.com/get/e03db60d2df21c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
         "meat": {
-          "grassfed": false,
+          "grassfed": true,
           "kobe": false,
           "bison": false,
           "angus": false,
-          "turkey": false,
-          "lamb": false,
+          "turkey": true,
+          "lamb": true,
           "elk": true
         }
       }
     ],
     "meats": {
       "grassfed": false,
-      "kobe": true,
+      "kobe": false,
       "bison": true,
-      "angus": true,
+      "angus": false,
       "turkey": false,
       "lamb": false,
       "elk": true
@@ -6386,145 +1963,48 @@
       "glutenFree": false
     },
     "challenges": {
-      "exists": true,
-      "name": "The Yummy Eat",
-      "description": "Tempor adipisicing id anim excepteur."
+      "exists": false,
+      "name": "The Yummy Devour",
+      "description": "Occaecat sint sunt fugiat aliquip ea cillum sunt."
     },
     "hours": {
       "days": "Monday - Sunday",
       "opening": "11:00AM",
-      "closing": "11:00PM",
+      "closing": "12:00PM",
       "closed": false
     }
   },
   {
-    "name": "Bob's Flesh & Turkey",
-    "address": "298 Tapscott Street, Chicago, IL, 60649",
+    "name": "Bacon Tavern",
+    "address": "426 Macon Street, Chicago, IL, 60616",
     "coords": [
-      -87.703126,
-      41.897957
+      -87.665897,
+      41.910529
     ],
-    "phone": "+1 (855) 586-3600",
-    "website": "www.anixang.com",
-    "price": 4,
+    "phone": "+1 (963) 414-2871",
+    "website": "www.manglo.com",
+    "price": 3,
     "foodtruck": false,
     "veggie": false,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delicious Cheesy Sandwich",
-        "description": "Sit commodo duis sit id nostrud quis fugiat culpa ea anim reprehenderit fugiat.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ef32b7092bf11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": false,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Heavenly Devour",
-      "description": "Aute ex duis cupidatat deserunt non do."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "9:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Café",
-    "address": "810 Herkimer Street, Chicago, IL, 60624",
-    "coords": [
-      -87.721217,
-      41.868456
-    ],
-    "phone": "+1 (850) 481-3007",
-    "website": "www.xleen.com",
-    "price": 1,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
+    "byob": false,
     "alcohol": true,
     "latenight": false,
     "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
     "burgers": [
       {
-        "name": "The Delectable Greasy Burger",
-        "description": "Proident labore Lorem ad magna et officia velit cillum cillum.",
+        "name": "The Sensational Double Burger",
+        "description": "Pariatur dolore quis excepteur aliqua pariatur incididunt sint quis.",
         "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e834b00e29f3033ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
         "meat": {
-          "grassfed": false,
+          "grassfed": true,
           "kobe": false,
           "bison": true,
           "angus": true,
-          "turkey": true,
+          "turkey": false,
           "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delightful Triple Sandwich",
-        "description": "Culpa mollit qui pariatur proident culpa magna ipsum consequat incididunt amet enim labore.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed36b5092dfc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Scrumtrulesant Double Burger",
-        "description": "Laboris eu duis laborum adipisicing veniam ex magna qui sint magna non proident consectetur est.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ee34b20b29f41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
           "elk": false
         }
       }
@@ -6532,8 +2012,154 @@
     "meats": {
       "grassfed": false,
       "kobe": false,
-      "bison": false,
+      "bison": true,
       "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Enticing Chew",
+      "description": "Adipisicing duis aliquip laboris excepteur sit voluptate anim laborum enim aute."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Bar",
+    "address": "713 Ridge Court, Chicago, IL, 60604",
+    "coords": [
+      -87.70464,
+      41.859724
+    ],
+    "phone": "+1 (906) 565-3097",
+    "website": "www.recrisys.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+    "burgers": [
+      {
+        "name": "The Yummy Double Burger",
+        "description": "Excepteur mollit duis amet laborum do consectetur ipsum ad occaecat deserunt consectetur incididunt.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Heavenly Eat",
+      "description": "Deserunt exercitation laboris do esse adipisicing."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Super Mario's BBQ",
+    "address": "924 Butler Street, Chicago, IL, 60626",
+    "coords": [
+      -87.674446,
+      41.873554
+    ],
+    "phone": "+1 (989) 572-3529",
+    "website": "www.lyrichord.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delightful Triple Burger",
+        "description": "Sit culpa reprehenderit mollit dolor proident labore.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Sensational Greasy Sandwich",
+        "description": "Laborum amet nostrud aute eiusmod enim.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": true,
+      "angus": true,
       "turkey": true,
       "lamb": false,
       "elk": true
@@ -6545,81 +2171,243 @@
     },
     "allergies": {
       "accommodates": false,
-      "glutenFree": true
+      "glutenFree": false
     },
     "challenges": {
       "exists": true,
-      "name": "The Enticing Graze",
-      "description": "Ad aliqua reprehenderit duis non veniam exercitation magna culpa anim."
+      "name": "The Yummy Chew",
+      "description": "Commodo est sunt pariatur ut et id enim fugiat consectetur cupidatat ut excepteur."
     },
     "hours": {
       "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "10:00PM",
+      "opening": "8:00AM",
+      "closing": "5:00PM",
       "closed": false
     }
   },
   {
-    "name": "Gourmet Buffet",
-    "address": "915 Belmont Avenue, Chicago, IL, 60642",
+    "name": "Old Ben's Café",
+    "address": "326 Wythe Place, Chicago, IL, 60601",
     "coords": [
-      -87.670345,
-      41.886543
+      -87.699247,
+      41.831869
     ],
-    "phone": "+1 (896) 449-3349",
-    "website": "www.wazzu.com",
-    "price": 4,
+    "phone": "+1 (863) 548-3007",
+    "website": "www.applidec.com",
+    "price": 3,
     "foodtruck": true,
     "veggie": false,
-    "byob": false,
-    "alcohol": true,
-    "latenight": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
     "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
     "burgers": [
       {
-        "name": "The Heavenly Double Burger",
-        "description": "Commodo aliquip duis id id aliqua aliquip irure commodo labore.",
-        "rating": 1,
+        "name": "The Sensational Double Sandwich",
+        "description": "Nisi nostrud et elit cupidatat occaecat do dolore.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Sensational Double Sandwich",
+        "description": "Sit qui ipsum consectetur nulla cillum aliqua excepteur.",
+        "rating": 3,
         "veggie": false,
-        "image": "https://pixabay.com/get/ee36b00d21fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
         "meat": {
           "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Eat",
+      "description": "Irure excepteur velit mollit incididunt eiusmod id eu tempor velit deserunt."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Tavern",
+    "address": "514 School Lane, Chicago, IL, 60604",
+    "coords": [
+      -87.705647,
+      41.844459
+    ],
+    "phone": "+1 (808) 550-2173",
+    "website": "www.dancerity.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+    "burgers": [
+      {
+        "name": "The Meaty Smeared Sandwich",
+        "description": "Nulla nisi aliqua veniam ea.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
+        "meat": {
+          "grassfed": false,
           "kobe": true,
           "bison": false,
           "angus": true,
           "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Delightful Double Burger",
-        "description": "Dolor voluptate in incididunt in nisi sint.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e835b00a2cf0013ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
           "lamb": true,
           "elk": true
         }
       },
       {
-        "name": "The Delectable Quadruple Sandwich",
-        "description": "Magna dolor consectetur amet mollit ipsum dolore ex minim nisi exercitation consectetur tempor fugiat.",
-        "rating": 0,
+        "name": "The Grilled Double Sandwich",
+        "description": "Irure irure non mollit veniam officia labore duis aute minim.",
+        "rating": 4,
         "veggie": false,
-        "image": "https://pixabay.com/get/e032b40920fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delicious Eat",
+      "description": "Aliqua enim pariatur ea laboris amet pariatur occaecat aliqua cillum do."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Old Ben's Lounge",
+    "address": "460 Middagh Street, Chicago, IL, 60631",
+    "coords": [
+      -87.634162,
+      41.876838
+    ],
+    "phone": "+1 (888) 411-2393",
+    "website": "www.prosely.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+    "burgers": [
+      {
+        "name": "The Grilled Smeared Burger",
+        "description": "Commodo mollit consectetur consequat qui consequat officia elit qui irure consectetur eu laborum laboris.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Enticing Double Sandwich",
+        "description": "Lorem amet velit cupidatat nostrud irure duis qui fugiat esse Lorem.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Grilled Double Burger",
+        "description": "Sint proident tempor ex laborum laboris.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": true,
           "bison": false,
-          "angus": false,
+          "angus": true,
           "turkey": false,
           "lamb": false,
           "elk": false
@@ -6631,14 +2419,14 @@
       "kobe": false,
       "bison": true,
       "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
+      "turkey": false,
+      "lamb": true,
+      "elk": true
     },
     "sides": {
       "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
+      "tots": false,
+      "macAndCheese": true
     },
     "allergies": {
       "accommodates": false,
@@ -6647,493 +2435,7 @@
     "challenges": {
       "exists": false,
       "name": "The Delicious Eat",
-      "description": "Culpa labore esse et officia incididunt nisi eu id consequat exercitation dolore Lorem ut voluptate."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "6:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Café",
-    "address": "317 Oakland Place, Chicago, IL, 60609",
-    "coords": [
-      -87.661194,
-      41.913963
-    ],
-    "phone": "+1 (871) 534-2958",
-    "website": "www.quinex.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
-    "burgers": [
-      {
-        "name": "The Jedi Master Double Sandwich",
-        "description": "Ea sint pariatur adipisicing cillum exercitation commodo nisi eiusmod occaecat.",
-        "rating": 4,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee33b1072ff11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delicious Cheesy Sandwich",
-        "description": "Cillum dolor nulla laboris eu labore occaecat ex est excepteur laborum ut ex.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee33b1072ff71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Jedi Master Triple Burger",
-        "description": "Nulla dolor occaecat exercitation pariatur aliquip nulla excepteur et dolor sint.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13cb30c20fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Eat",
-      "description": "Sunt mollit aute aute ea qui Lorem magna officia ea."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "10:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gourmet Bistro",
-    "address": "871 Indiana Place, Chicago, IL, 60604",
-    "coords": [
-      -87.731951,
-      41.891915
-    ],
-    "phone": "+1 (897) 423-2005",
-    "website": "www.kongene.com",
-    "price": 0,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
-    "burgers": [
-      {
-        "name": "The Jedi Master Triple Sandwich",
-        "description": "Deserunt est veniam ea eiusmod ea laboris esse exercitation magna ipsum ipsum.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e834b1062dfc063ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delicious Devour",
-      "description": "Quis aliqua est excepteur ipsum Lorem ullamco ad."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Tavern",
-    "address": "126 Clarendon Road, Chicago, IL, 60068",
-    "coords": [
-      -87.697099,
-      41.85482
-    ],
-    "phone": "+1 (964) 498-2882",
-    "website": "www.exodoc.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delectable Smeared Burger",
-        "description": "Ea ipsum quis Lorem ut proident elit irure voluptate enim sunt.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee37b9072df11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Yummy Cheesy Burger",
-        "description": "Esse nisi reprehenderit amet dolore.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ed31b00a2ff31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delicious Cheesy Sandwich",
-        "description": "Anim adipisicing labore culpa adipisicing est ex.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ed31b40a20f51c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Delectable Eat",
-      "description": "Aliquip est sint culpa velit non officia anim et consectetur adipisicing proident ex reprehenderit do."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "10:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Chophouse",
-    "address": "736 Montana Place, Chicago, IL, 60642",
-    "coords": [
-      -87.677007,
-      41.828054
-    ],
-    "phone": "+1 (819) 417-3850",
-    "website": "www.omnigog.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
-    "burgers": [
-      {
-        "name": "The Filling Double Sandwich",
-        "description": "Esse elit minim aute elit eu eu tempor.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ea30b50f2efd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Heavenly Double Sandwich",
-        "description": "Esse consectetur dolore commodo eu amet proident aliqua.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e030b60d2af31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Delectable Cheesy Sandwich",
-        "description": "Sit duis eu quis sit fugiat dolor occaecat est.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec35b10f2df01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Yummy Eat",
-      "description": "Ut aliquip mollit irure est incididunt."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Turbo Between the Bunz",
-    "address": "363 Fane Court, Chicago, IL, 60632",
-    "coords": [
-      -87.638367,
-      41.881763
-    ],
-    "phone": "+1 (803) 435-3331",
-    "website": "www.firewax.com",
-    "price": 3,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
-    "burgers": [
-      {
-        "name": "The Thick Cheesy Sandwich",
-        "description": "Officia esse amet nostrud labore nostrud exercitation pariatur sit excepteur aute dolore aute veniam incididunt.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e032b40920fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delectable Eat",
-      "description": "Sint enim irure minim irure anim."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Organic Buffet",
-    "address": "928 Woodruff Avenue, Chicago, IL, 60625",
-    "coords": [
-      -87.660004,
-      41.852732
-    ],
-    "phone": "+1 (828) 459-2299",
-    "website": "www.codax.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delicious Greasy Burger",
-        "description": "Culpa eiusmod quis commodo dolore ut pariatur veniam in enim.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e13cb6092af01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": true,
-          "turkey": true,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delectable Devour",
-      "description": "Nisi do adipisicing mollit exercitation labore."
+      "description": "Pariatur enim duis veniam nisi."
     },
     "hours": {
       "days": "Monday - Sunday",
@@ -7143,246 +2445,52 @@
     }
   },
   {
-    "name": "Bacon Burgers",
-    "address": "304 Lawrence Street, Chicago, IL, 60706",
+    "name": "Super Mario's Between the Bunz",
+    "address": "566 Fenimore Street, Chicago, IL, 60637",
     "coords": [
-      -87.63722,
-      41.855036
+      -87.70497,
+      41.879519
     ],
-    "phone": "+1 (824) 583-2409",
-    "website": "www.kenegy.com",
-    "price": 2,
+    "phone": "+1 (875) 442-3270",
+    "website": "www.nebulean.com",
+    "price": 4,
     "foodtruck": true,
     "veggie": false,
     "byob": false,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
-    "burgers": [
-      {
-        "name": "The Heavenly Smeared Sandwich",
-        "description": "Ipsum consequat proident id cillum esse eiusmod.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e032b40920fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Scrum-dilly-omcious Triple Burger",
-        "description": "Ea ea enim eiusmod dolore.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e835b5072ef0073ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Sensational Smeared Burger",
-        "description": "Magna ipsum anim velit dolor duis.",
-        "rating": 2,
-        "veggie": true,
-        "image": "https://pixabay.com/get/eb31b7072af61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Meaty Devour",
-      "description": "Consequat officia dolor enim exercitation fugiat fugiat exercitation mollit nulla est."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "8:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Skywalker's Burgers",
-    "address": "549 Berriman Street, Chicago, IL, 60643",
-    "coords": [
-      -87.7375,
-      41.834876
-    ],
-    "phone": "+1 (801) 589-3578",
-    "website": "www.veraq.com",
-    "price": 3,
-    "foodtruck": true,
-    "veggie": true,
-    "byob": true,
     "alcohol": true,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
-    "burgers": [
-      {
-        "name": "The Filling Cheesy Sandwich",
-        "description": "Cupidatat cupidatat ad dolor aliqua irure et consectetur dolore quis labore.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ee30b60a2bfc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Scrumtrulesant Triple Sandwich",
-        "description": "Consequat incididunt nulla exercitation qui cupidatat.",
-        "rating": 0,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e137b60c29f41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": true,
-      "angus": false,
-      "turkey": true,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Meaty Chew",
-      "description": "Anim esse in culpa reprehenderit consectetur exercitation est anim."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "7:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Bob's Café",
-    "address": "615 Rochester Avenue, Chicago, IL, 60661",
-    "coords": [
-      -87.719061,
-      41.917514
-    ],
-    "phone": "+1 (962) 564-3711",
-    "website": "www.idego.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": false,
-    "alcohol": false,
     "latenight": true,
     "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
     "burgers": [
       {
-        "name": "The Sensational Triple Burger",
-        "description": "Cupidatat consectetur sint non magna non minim ut aliqua.",
-        "rating": 2,
+        "name": "The Meaty Cheesy Sandwich",
+        "description": "Sunt veniam exercitation Lorem anim.",
+        "rating": 3,
         "veggie": true,
-        "image": "https://pixabay.com/get/e131b4082df41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": true,
           "bison": true,
           "angus": false,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Grilled Greasy Sandwich",
-        "description": "Ullamco ipsum amet laboris laboris commodo est et id et velit esse dolore aliquip.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/ec31b90929f11c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
           "turkey": true,
-          "lamb": false,
-          "elk": false
+          "lamb": true,
+          "elk": true
         }
       },
       {
-        "name": "The Yummy Greasy Sandwich",
-        "description": "Enim exercitation esse do velit consectetur magna aliquip aute labore sint nulla.",
+        "name": "The Scrumtrulesant Double Sandwich",
+        "description": "Sit adipisicing nostrud cupidatat eiusmod eiusmod proident proident.",
         "rating": 2,
         "veggie": true,
-        "image": "https://pixabay.com/get/e132b50828f71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
         "meat": {
           "grassfed": true,
-          "kobe": false,
+          "kobe": true,
           "bison": true,
-          "angus": false,
+          "angus": true,
           "turkey": true,
-          "lamb": false,
+          "lamb": true,
           "elk": true
         }
       }
@@ -7390,385 +2498,93 @@
     "meats": {
       "grassfed": false,
       "kobe": true,
-      "bison": false,
+      "bison": true,
       "angus": false,
       "turkey": false,
-      "lamb": false,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Graze",
-      "description": "Commodo esse tempor labore consectetur velit sunt."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "11:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Tom's BBQ",
-    "address": "918 Dare Court, Chicago, IL, 60601",
-    "coords": [
-      -87.73803,
-      41.857142
-    ],
-    "phone": "+1 (931) 556-3353",
-    "website": "www.ovation.com",
-    "price": 4,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
-    "burgers": [
-      {
-        "name": "The Grilled Double Sandwich",
-        "description": "Aute elit pariatur eu excepteur proident esse laborum occaecat cupidatat incididunt.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e834b1062dfc063ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
       "lamb": false,
       "elk": false
     },
     "sides": {
-      "duckFries": true,
+      "duckFries": false,
       "tots": true,
-      "macAndCheese": true
+      "macAndCheese": false
     },
     "allergies": {
-      "accommodates": false,
+      "accommodates": true,
       "glutenFree": false
     },
     "challenges": {
       "exists": true,
       "name": "The Delectable Devour",
-      "description": "Laboris tempor tempor ut dolor sint est ullamco."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "9:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Skywalker's Fusion",
-    "address": "820 Evergreen Avenue, Chicago, IL, 60610",
-    "coords": [
-      -87.660804,
-      41.880954
-    ],
-    "phone": "+1 (984) 569-3268",
-    "website": "www.geofarm.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
-    "burgers": [
-      {
-        "name": "The Scrumtrulesant Greasy Burger",
-        "description": "Excepteur ullamco quis adipisicing amet ipsum.",
-        "rating": 3,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e13db8062bf41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": false,
-      "bison": true,
-      "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": true,
-      "tots": true,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Enticing Graze",
-      "description": "Minim consequat quis sint proident elit veniam in sint adipisicing veniam laboris."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "10:00AM",
-      "closing": "5:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Skywalker's Burgers",
-    "address": "684 Otsego Street, Chicago, IL, 60068",
-    "coords": [
-      -87.671122,
-      41.841393
-    ],
-    "phone": "+1 (887) 565-3880",
-    "website": "www.escenta.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": true,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
-    "burgers": [
-      {
-        "name": "The Turbo Greasy Burger",
-        "description": "Ex dolor amet cillum est officia sit commodo.",
-        "rating": 4,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e131b4082df41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Grilled Cheesy Sandwich",
-        "description": "Ad amet pariatur quis reprehenderit proident et sunt veniam minim duis do officia mollit.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e834b1062dfc063ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": false,
-      "bison": false,
-      "angus": false,
-      "turkey": true,
-      "lamb": false,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Delectable Eat",
-      "description": "Nulla laborum in et dolor laboris."
+      "description": "Fugiat minim consectetur reprehenderit nisi elit et consequat quis consectetur excepteur."
     },
     "hours": {
       "days": "Monday - Sunday",
       "opening": "12:00AM",
-      "closing": "6:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Skywalker's Fusion",
-    "address": "397 Oak Street, Chicago, IL, 60610",
-    "coords": [
-      -87.698725,
-      41.889587
-    ],
-    "phone": "+1 (850) 424-2388",
-    "website": "www.hawkster.com",
-    "price": 2,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": false,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
-    "burgers": [
-      {
-        "name": "The Filling Cheesy Burger",
-        "description": "Cillum sunt ipsum veniam cupidatat nisi.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ec37b30b2ef01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      },
-      {
-        "name": "The King Kong Triple Sandwich",
-        "description": "Adipisicing veniam sint consectetur veniam fugiat irure do sit est.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/eb34b50e2df71c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": true,
-      "kobe": true,
-      "bison": false,
-      "angus": true,
-      "turkey": true,
-      "lamb": true,
-      "elk": true
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": true,
-      "macAndCheese": false
-    },
-    "allergies": {
-      "accommodates": false,
-      "glutenFree": true
-    },
-    "challenges": {
-      "exists": true,
-      "name": "The Enticing Devour",
-      "description": "Sunt dolor excepteur commodo commodo minim officia minim id officia deserunt do."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "11:00AM",
       "closing": "11:00PM",
       "closed": false
     }
   },
   {
-    "name": "Bowsers Café",
-    "address": "145 Schweikerts Walk, Chicago, IL, 60606",
+    "name": "Skywalker's Buffet",
+    "address": "769 Campus Place, Chicago, IL, 60655",
     "coords": [
-      -87.677783,
-      41.890485
+      -87.689085,
+      41.921559
     ],
-    "phone": "+1 (805) 527-2840",
-    "website": "www.supremia.com",
-    "price": 0,
-    "foodtruck": false,
-    "veggie": true,
-    "byob": true,
-    "alcohol": true,
+    "phone": "+1 (867) 513-3346",
+    "website": "www.zidant.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
     "latenight": false,
     "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
     "burgers": [
       {
-        "name": "The Meaty Quadruple Sandwich",
-        "description": "Non sunt ex eu magna.",
+        "name": "The Delightful Smeared Burger",
+        "description": "Deserunt Lorem aliqua dolore Lorem sit occaecat nisi exercitation nulla.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Thick Double Burger",
+        "description": "Laboris voluptate laboris tempor veniam ut esse.",
         "rating": 4,
         "veggie": true,
-        "image": "https://pixabay.com/get/ef37b30728fd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
         "meat": {
-          "grassfed": true,
+          "grassfed": false,
           "kobe": true,
-          "bison": true,
-          "angus": false,
+          "bison": false,
+          "angus": true,
           "turkey": true,
           "lamb": true,
-          "elk": true
+          "elk": false
         }
       },
       {
-        "name": "The Yummy Quadruple Sandwich",
-        "description": "Cupidatat ipsum elit pariatur ullamco.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ee37b10f2cfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "name": "The Grilled Triple Burger",
+        "description": "Labore adipisicing quis ut veniam labore voluptate veniam do.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
         "meat": {
-          "grassfed": false,
+          "grassfed": true,
           "kobe": false,
           "bison": true,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The King Kong Quadruple Sandwich",
-        "description": "Et id voluptate magna nostrud.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/ea30b70e2ff41c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": false,
-          "bison": false,
           "angus": false,
           "turkey": false,
           "lamb": false,
@@ -7778,93 +2594,12 @@
     ],
     "meats": {
       "grassfed": true,
-      "kobe": true,
+      "kobe": false,
       "bison": false,
       "angus": true,
-      "turkey": false,
-      "lamb": true,
-      "elk": false
-    },
-    "sides": {
-      "duckFries": false,
-      "tots": false,
-      "macAndCheese": true
-    },
-    "allergies": {
-      "accommodates": true,
-      "glutenFree": false
-    },
-    "challenges": {
-      "exists": false,
-      "name": "The Yummy Graze",
-      "description": "Non ad consequat magna do et quis sint culpa pariatur id sit."
-    },
-    "hours": {
-      "days": "Monday - Sunday",
-      "opening": "8:00AM",
-      "closing": "12:00PM",
-      "closed": false
-    }
-  },
-  {
-    "name": "Gluten-Free Bar",
-    "address": "914 Delevan Street, Chicago, IL, 60624",
-    "coords": [
-      -87.649665,
-      41.871072
-    ],
-    "phone": "+1 (856) 583-3215",
-    "website": "www.aquamate.com",
-    "price": 4,
-    "foodtruck": true,
-    "veggie": false,
-    "byob": false,
-    "alcohol": false,
-    "latenight": true,
-    "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
-    "burgers": [
-      {
-        "name": "The Delectable Greasy Sandwich",
-        "description": "Sunt ad excepteur proident non dolor ut ut consectetur duis elit duis.",
-        "rating": 1,
-        "veggie": true,
-        "image": "https://pixabay.com/get/e032b40920fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": false,
-          "bison": false,
-          "angus": false,
-          "turkey": true,
-          "lamb": false,
-          "elk": false
-        }
-      },
-      {
-        "name": "The Turbo Smeared Sandwich",
-        "description": "Lorem irure cupidatat ullamco Lorem culpa.",
-        "rating": 3,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e135b0062cf61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": false,
-          "angus": false,
-          "turkey": false,
-          "lamb": true,
-          "elk": true
-        }
-      }
-    ],
-    "meats": {
-      "grassfed": false,
-      "kobe": true,
-      "bison": false,
-      "angus": false,
       "turkey": true,
-      "lamb": true,
-      "elk": true
+      "lamb": false,
+      "elk": false
     },
     "sides": {
       "duckFries": false,
@@ -7878,77 +2613,61 @@
     "challenges": {
       "exists": true,
       "name": "The Delicious Graze",
-      "description": "Nulla Lorem ea tempor amet officia commodo."
+      "description": "Magna reprehenderit nisi reprehenderit consectetur labore laborum laboris dolor laboris duis consectetur ex."
     },
     "hours": {
       "days": "Monday - Sunday",
-      "opening": "12:00AM",
-      "closing": "6:00PM",
+      "opening": "10:00AM",
+      "closing": "8:00PM",
       "closed": false
     }
   },
   {
-    "name": "Gourmet Café",
-    "address": "716 Randolph Street, Chicago, IL, 60636",
+    "name": "Bob's Sandwiches",
+    "address": "788 Durland Place, Chicago, IL, 60639",
     "coords": [
-      -87.694404,
-      41.828727
+      -87.706903,
+      41.89872
     ],
-    "phone": "+1 (939) 595-3451",
-    "website": "www.grok.com",
-    "price": 2,
+    "phone": "+1 (864) 525-3453",
+    "website": "www.zensus.com",
+    "price": 1,
     "foodtruck": false,
     "veggie": true,
-    "byob": true,
+    "byob": false,
     "alcohol": false,
     "latenight": true,
     "outdoor": true,
-    "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
     "burgers": [
       {
-        "name": "The Scrum-dilly-omcious Quadruple Sandwich",
-        "description": "Amet deserunt ut magna magna aute elit elit.",
-        "rating": 2,
+        "name": "The Filling Greasy Burger",
+        "description": "Mollit occaecat eu adipisicing voluptate incididunt aute tempor excepteur nisi amet nulla cillum.",
+        "rating": 4,
         "veggie": false,
-        "image": "https://pixabay.com/get/ee36b00d21fc1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
-        "meat": {
-          "grassfed": false,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": false,
-          "lamb": false,
-          "elk": true
-        }
-      },
-      {
-        "name": "The Heavenly Quadruple Sandwich",
-        "description": "Laboris aliqua anim laborum adipisicing officia est adipisicing ipsum tempor ea.",
-        "rating": 2,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e031b40c2af61c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": false,
-          "bison": true,
-          "angus": true,
+          "bison": false,
+          "angus": false,
           "turkey": false,
           "lamb": false,
-          "elk": true
+          "elk": false
         }
       },
       {
-        "name": "The Jedi Master Triple Burger",
-        "description": "Laboris amet et proident ea elit.",
-        "rating": 0,
+        "name": "The Scrumtrulesant Triple Burger",
+        "description": "Non sit ut et duis proident.",
+        "rating": 2,
         "veggie": true,
-        "image": "https://pixabay.com/get/ee3db20a2cfd1c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
         "meat": {
           "grassfed": false,
           "kobe": false,
-          "bison": true,
-          "angus": false,
-          "turkey": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
           "lamb": true,
           "elk": true
         }
@@ -7957,11 +2676,254 @@
     "meats": {
       "grassfed": true,
       "kobe": false,
-      "bison": true,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Heavenly Chew",
+      "description": "Pariatur sunt fugiat cupidatat eu."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Organic Pub",
+    "address": "873 Keap Street, Chicago, IL, 60602",
+    "coords": [
+      -87.639515,
+      41.877715
+    ],
+    "phone": "+1 (858) 439-2082",
+    "website": "www.katakana.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+    "burgers": [
+      {
+        "name": "The Sensational Double Burger",
+        "description": "Dolor id sint ad aliqua cupidatat consectetur laborum ex qui dolore.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delicious Devour",
+      "description": "Lorem nulla dolor reprehenderit aliquip duis labore et labore commodo id exercitation."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gluten-Free Burgers",
+    "address": "547 Little Street, Chicago, IL, 60615",
+    "coords": [
+      -87.675744,
+      41.921016
+    ],
+    "phone": "+1 (856) 500-2428",
+    "website": "www.acusage.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delectable Double Burger",
+        "description": "Labore id magna reprehenderit duis minim sint.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Scrum-dilly-omcious Smeared Burger",
+        "description": "Reprehenderit excepteur in cillum duis tempor officia irure proident do ea eiusmod quis sit.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
       "angus": false,
       "turkey": true,
       "lamb": false,
-      "elk": true
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Yummy Eat",
+      "description": "Culpa eiusmod ipsum exercitation labore enim minim."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gluten-Free Burgers",
+    "address": "900 Rock Street, Chicago, IL, 60642",
+    "coords": [
+      -87.658588,
+      41.871741
+    ],
+    "phone": "+1 (816) 475-3977",
+    "website": "www.radiantix.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delicious Greasy Sandwich",
+        "description": "Cillum commodo aliquip cillum incididunt nostrud sit in in esse culpa velit in ea laboris.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Enticing Greasy Burger",
+        "description": "Exercitation ut sit ipsum exercitation dolor ipsum.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Filling Greasy Burger",
+        "description": "Occaecat magna voluptate in elit eu nulla ea.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": true,
+      "elk": false
     },
     "sides": {
       "duckFries": false,
@@ -7974,43 +2936,140 @@
     },
     "challenges": {
       "exists": false,
-      "name": "The Enticing Graze",
-      "description": "Eu mollit Lorem magna incididunt ex consequat."
+      "name": "The Delectable Chew",
+      "description": "Irure aute enim voluptate pariatur ad qui aute in."
     },
     "hours": {
       "days": "Monday - Sunday",
-      "opening": "11:00AM",
-      "closing": "7:00PM",
+      "opening": "10:00AM",
+      "closing": "5:00PM",
       "closed": false
     }
   },
   {
-    "name": "Super Mario's Bar",
-    "address": "606 Maujer Street, Chicago, IL, 60714",
+    "name": "Bob's Bar",
+    "address": "756 Forbell Street, Chicago, IL, 60643",
     "coords": [
-      -87.723524,
-      41.835472
+      -87.69455,
+      41.903863
     ],
-    "phone": "+1 (842) 511-2254",
-    "website": "www.bicol.com",
-    "price": 3,
-    "foodtruck": false,
+    "phone": "+1 (981) 509-2951",
+    "website": "www.digirang.com",
+    "price": 1,
+    "foodtruck": true,
     "veggie": true,
-    "byob": false,
+    "byob": true,
     "alcohol": false,
-    "latenight": true,
+    "latenight": false,
     "outdoor": false,
     "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
     "burgers": [
       {
-        "name": "The Jedi Master Quadruple Burger",
-        "description": "Enim proident sunt aute magna adipisicing reprehenderit dolor.",
-        "rating": 1,
+        "name": "The Turbo Triple Burger",
+        "description": "Lorem veniam velit incididunt laborum excepteur non ut quis anim.",
+        "rating": 4,
         "veggie": false,
-        "image": "https://pixabay.com/get/ec35b10f2df01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Scrum-dilly-omcious Double Sandwich",
+        "description": "Ex commodo sunt mollit dolore.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Meaty Devour",
+      "description": "Et amet anim excepteur nisi eu eu reprehenderit."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "12:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bob's BBQ",
+    "address": "620 Moore Street, Chicago, IL, 60609",
+    "coords": [
+      -87.643669,
+      41.864733
+    ],
+    "phone": "+1 (827) 406-3791",
+    "website": "www.norsul.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+    "burgers": [
+      {
+        "name": "The Filling Cheesy Burger",
+        "description": "Cupidatat minim eiusmod in eiusmod consectetur minim Lorem est voluptate pariatur irure.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Delightful Triple Burger",
+        "description": "Magna consequat fugiat reprehenderit voluptate in nostrud.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
           "bison": true,
           "angus": false,
           "turkey": true,
@@ -8019,15 +3078,2250 @@
         }
       },
       {
-        "name": "The Turbo Quadruple Sandwich",
-        "description": "Est et elit aliqua labore commodo incididunt et amet esse commodo sint enim magna.",
+        "name": "The Enticing Triple Sandwich",
+        "description": "Nulla est qui qui pariatur nostrud do.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Eat",
+      "description": "Dolore deserunt ea cillum deserunt consequat irure esse deserunt aute."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Lounge",
+    "address": "234 Miller Avenue, Chicago, IL, 60642",
+    "coords": [
+      -87.654179,
+      41.889701
+    ],
+    "phone": "+1 (836) 527-2848",
+    "website": "www.zillatide.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+    "burgers": [
+      {
+        "name": "The Jedi Master Cheesy Sandwich",
+        "description": "Ut labore dolore nulla dolor est do Lorem ad do dolor.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Delicious Quadruple Burger",
+        "description": "Aliquip irure tempor Lorem dolore occaecat enim anim sunt aliquip aliqua.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Graze",
+      "description": "Ut cupidatat id elit consequat commodo consectetur do Lorem magna velit nulla."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Super Mario's Buffet",
+    "address": "190 Drew Street, Chicago, IL, 60634",
+    "coords": [
+      -87.653052,
+      41.893019
+    ],
+    "phone": "+1 (925) 410-2625",
+    "website": "www.aquazure.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+    "burgers": [
+      {
+        "name": "The Sensational Triple Sandwich",
+        "description": "Consequat incididunt non aliqua ullamco non proident exercitation labore esse irure incididunt deserunt excepteur id.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Yummy Cheesy Burger",
+        "description": "Ad sunt enim eiusmod ad.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Scrumtrulesant Quadruple Sandwich",
+        "description": "Nostrud voluptate excepteur aliquip id quis do et esse elit nulla adipisicing eu.",
         "rating": 1,
         "veggie": false,
-        "image": "https://pixabay.com/get/e834b00e29f3033ed95c4518b74d4195e474e1d704b0154497f2c17ba4efb0_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Chew",
+      "description": "Ut irure esse duis minim ea non pariatur."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Organic Café",
+    "address": "989 Utica Avenue, Chicago, IL, 60707",
+    "coords": [
+      -87.6394,
+      41.911727
+    ],
+    "phone": "+1 (865) 466-3749",
+    "website": "www.realysis.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+    "burgers": [
+      {
+        "name": "The Thick Quadruple Burger",
+        "description": "Ullamco pariatur sint cupidatat dolore proident laboris aliqua ex enim reprehenderit.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delightful Quadruple Sandwich",
+        "description": "Sunt dolor eiusmod dolor fugiat dolor minim.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Turbo Greasy Burger",
+        "description": "Est ullamco ex minim do anim irure fugiat sint enim laboris.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
         "meat": {
           "grassfed": true,
           "kobe": false,
           "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Heavenly Chew",
+      "description": "Veniam ut do officia velit."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Café",
+    "address": "139 Havemeyer Street, Chicago, IL, 60623",
+    "coords": [
+      -87.698828,
+      41.832461
+    ],
+    "phone": "+1 (987) 595-2901",
+    "website": "www.keeg.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+    "burgers": [
+      {
+        "name": "The Yummy Greasy Burger",
+        "description": "Aliquip ad qui fugiat officia veniam consequat esse velit do dolor veniam.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Heavenly Smeared Sandwich",
+        "description": "Ad non ipsum aliquip fugiat esse tempor excepteur esse dolor proident esse duis nisi.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Turbo Greasy Sandwich",
+        "description": "Ullamco non laboris duis commodo.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Enticing Chew",
+      "description": "Eu mollit magna occaecat officia est aliquip aute et culpa anim nisi labore dolor."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Fusion",
+    "address": "885 Kenmore Terrace, Chicago, IL, 60644",
+    "coords": [
+      -87.677404,
+      41.881048
+    ],
+    "phone": "+1 (822) 454-3492",
+    "website": "www.vitricomp.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+    "burgers": [
+      {
+        "name": "The Scrum-dilly-omcious Triple Sandwich",
+        "description": "Incididunt Lorem velit do elit ullamco cupidatat cillum laborum aliquip duis dolore aute consectetur.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Turbo Double Burger",
+        "description": "Commodo excepteur Lorem in ad.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Enticing Devour",
+      "description": "Reprehenderit laboris reprehenderit irure sunt aliquip."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Lounge",
+    "address": "743 Everit Street, Chicago, IL, 60630",
+    "coords": [
+      -87.683271,
+      41.87538
+    ],
+    "phone": "+1 (806) 431-2139",
+    "website": "www.sultrax.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+    "burgers": [
+      {
+        "name": "The King Kong Triple Burger",
+        "description": "Lorem duis laboris aliquip in quis labore ullamco.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Graze",
+      "description": "Esse ipsum magna cupidatat do aliqua veniam consectetur adipisicing quis id et dolor duis."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Tom's Between the Bunz",
+    "address": "632 Logan Street, Chicago, IL, 60649",
+    "coords": [
+      -87.731621,
+      41.829775
+    ],
+    "phone": "+1 (980) 554-3417",
+    "website": "www.multron.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+    "burgers": [
+      {
+        "name": "The Enticing Greasy Burger",
+        "description": "Commodo fugiat ullamco qui duis veniam irure Lorem laboris ipsum id consequat aliqua irure.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Jedi Master Smeared Sandwich",
+        "description": "Commodo sunt minim deserunt ea quis exercitation cupidatat laboris eu.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delicious Graze",
+      "description": "Amet est aliqua non pariatur aute exercitation laborum consectetur."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Skywalker's Café",
+    "address": "363 Kathleen Court, Chicago, IL, 60068",
+    "coords": [
+      -87.66849,
+      41.903144
+    ],
+    "phone": "+1 (869) 490-2355",
+    "website": "www.phuel.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+    "burgers": [
+      {
+        "name": "The Grilled Quadruple Burger",
+        "description": "Amet non nisi magna voluptate sint eu cupidatat est voluptate magna do ut.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Scrumtrulesant Double Burger",
+        "description": "Anim proident mollit adipisicing est consequat mollit esse velit deserunt proident laborum.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Yummy Graze",
+      "description": "In qui amet nulla ad fugiat culpa ut."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Buffet",
+    "address": "734 Paerdegat Avenue, Chicago, IL, 60628",
+    "coords": [
+      -87.68066,
+      41.876255
+    ],
+    "phone": "+1 (870) 600-3326",
+    "website": "www.asimiline.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delectable Smeared Sandwich",
+        "description": "Aute voluptate ex sint incididunt eu sunt ullamco tempor qui voluptate Lorem.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Scrum-dilly-omcious Quadruple Sandwich",
+        "description": "Fugiat ea laborum in culpa.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Sensational Cheesy Sandwich",
+        "description": "Cupidatat deserunt est irure tempor reprehenderit nulla exercitation voluptate officia veniam elit aliqua eiusmod fugiat.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delicious Graze",
+      "description": "Occaecat enim culpa Lorem amet anim dolor nisi sint."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Flesh & Turkey",
+    "address": "221 Dearborn Court, Chicago, IL, 60707",
+    "coords": [
+      -87.65112,
+      41.856465
+    ],
+    "phone": "+1 (937) 501-2882",
+    "website": "www.kineticut.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+    "burgers": [
+      {
+        "name": "The Jedi Master Quadruple Burger",
+        "description": "Exercitation eiusmod mollit consectetur ullamco reprehenderit consectetur.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Devour",
+      "description": "Reprehenderit voluptate sint esse dolore voluptate id labore incididunt eu anim ex culpa mollit."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bob's Pub",
+    "address": "675 Ralph Avenue, Chicago, IL, 60622",
+    "coords": [
+      -87.64344,
+      41.831167
+    ],
+    "phone": "+1 (827) 571-2207",
+    "website": "www.deminimum.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+    "burgers": [
+      {
+        "name": "The Meaty Cheesy Sandwich",
+        "description": "Fugiat deserunt est non velit commodo dolor aute sunt ut eu est cupidatat.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Enticing Devour",
+      "description": "Non aute aliquip ex Lorem nulla exercitation nostrud."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bob's Buffet",
+    "address": "845 Provost Street, Chicago, IL, 60649",
+    "coords": [
+      -87.681057,
+      41.831456
+    ],
+    "phone": "+1 (821) 413-2397",
+    "website": "www.ramjob.com",
+    "price": 2,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delicious Triple Burger",
+        "description": "Ut incididunt culpa incididunt ullamco.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Scrumtrulesant Quadruple Sandwich",
+        "description": "Eu esse mollit anim tempor nostrud officia nostrud consequat.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Yummy Chew",
+      "description": "Ipsum duis dolore ipsum proident."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Bar",
+    "address": "574 Lott Place, Chicago, IL, 60623",
+    "coords": [
+      -87.668873,
+      41.883494
+    ],
+    "phone": "+1 (907) 448-2607",
+    "website": "www.tropoli.com",
+    "price": 2,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+    "burgers": [
+      {
+        "name": "The Scrum-dilly-omcious Triple Burger",
+        "description": "Sint nulla quis amet mollit do qui consequat velit.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The King Kong Triple Sandwich",
+        "description": "Eu velit nisi magna aliquip sint veniam anim consectetur in in quis culpa.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Meaty Graze",
+      "description": "Ut qui in exercitation qui proident ullamco."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Turbo Chophouse",
+    "address": "588 Village Court, Chicago, IL, 60654",
+    "coords": [
+      -87.724135,
+      41.867968
+    ],
+    "phone": "+1 (956) 564-2551",
+    "website": "www.comveyer.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+    "burgers": [
+      {
+        "name": "The Meaty Triple Burger",
+        "description": "Ad laboris quis ut ipsum pariatur consequat veniam aliquip nisi pariatur veniam incididunt ut nisi.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Thick Cheesy Burger",
+        "description": "Irure anim commodo ut veniam pariatur adipisicing fugiat ullamco.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delectable Graze",
+      "description": "Voluptate ut id aliqua duis velit aliqua fugiat magna eu pariatur."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Super Mario's Burgers",
+    "address": "563 Morgan Avenue, Chicago, IL, 60068",
+    "coords": [
+      -87.718615,
+      41.923046
+    ],
+    "phone": "+1 (898) 525-2593",
+    "website": "www.indexia.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+    "burgers": [
+      {
+        "name": "The King Kong Greasy Burger",
+        "description": "Proident proident officia consequat consequat qui deserunt.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Thick Greasy Burger",
+        "description": "Enim voluptate minim id aliquip aute ut sint pariatur consectetur adipisicing pariatur enim pariatur aute.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Enticing Chew",
+      "description": "Magna in consectetur commodo anim laboris."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gluten-Free Café",
+    "address": "750 Wortman Avenue, Chicago, IL, 60628",
+    "coords": [
+      -87.665675,
+      41.865435
+    ],
+    "phone": "+1 (880) 434-2996",
+    "website": "www.koogle.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+    "burgers": [
+      {
+        "name": "The Scrum-dilly-omcious Smeared Burger",
+        "description": "Ut Lorem magna consequat magna dolore.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Filling Smeared Burger",
+        "description": "Enim voluptate enim ad ad velit mollit sunt Lorem.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delicious Graze",
+      "description": "Labore exercitation velit dolore sunt deserunt."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "5:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Bar",
+    "address": "546 Harway Avenue, Chicago, IL, 60645",
+    "coords": [
+      -87.693981,
+      41.851733
+    ],
+    "phone": "+1 (855) 543-2458",
+    "website": "www.accuprint.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delectable Triple Sandwich",
+        "description": "Ipsum et id adipisicing id labore duis ex ut tempor reprehenderit.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Meaty Quadruple Burger",
+        "description": "Adipisicing elit ipsum laborum deserunt nulla commodo cillum nisi aliqua ipsum est nisi ex.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Turbo Quadruple Sandwich",
+        "description": "Veniam nisi incididunt eiusmod excepteur.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Yummy Chew",
+      "description": "Duis non excepteur nostrud occaecat veniam ad veniam."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Turbo Cantina",
+    "address": "986 Walker Court, Chicago, IL, 60068",
+    "coords": [
+      -87.684387,
+      41.847518
+    ],
+    "phone": "+1 (939) 531-2363",
+    "website": "www.kidstock.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+    "burgers": [
+      {
+        "name": "The Sensational Smeared Sandwich",
+        "description": "Et aute anim voluptate sint elit voluptate esse incididunt ipsum sint sit laborum magna aute.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Meaty Chew",
+      "description": "Eu do non dolore eiusmod adipisicing adipisicing est voluptate sit consequat."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Turbo Sandwiches",
+    "address": "523 Glenwood Road, Chicago, IL, 60632",
+    "coords": [
+      -87.721,
+      41.91502
+    ],
+    "phone": "+1 (830) 506-2513",
+    "website": "www.aquasure.com",
+    "price": 1,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+    "burgers": [
+      {
+        "name": "The Turbo Greasy Burger",
+        "description": "Ad deserunt aliqua ad pariatur.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Grilled Greasy Sandwich",
+        "description": "Nostrud commodo cupidatat duis tempor officia ea in enim commodo minim.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Chew",
+      "description": "Aute aliquip non ea Lorem dolor officia ad veniam cupidatat amet incididunt commodo velit voluptate."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bob's Bistro",
+    "address": "936 Lincoln Place, Chicago, IL, 60637",
+    "coords": [
+      -87.684648,
+      41.851381
+    ],
+    "phone": "+1 (900) 594-2657",
+    "website": "www.flyboyz.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+    "burgers": [
+      {
+        "name": "The Jedi Master Cheesy Sandwich",
+        "description": "Non officia anim dolor minim reprehenderit qui magna eiusmod pariatur deserunt.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delectable Graze",
+      "description": "Lorem ipsum ut ullamco irure sunt ut excepteur nisi dolor."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Old Ben's Pub",
+    "address": "246 Oceanview Avenue, Chicago, IL, 60656",
+    "coords": [
+      -87.729373,
+      41.862953
+    ],
+    "phone": "+1 (955) 560-2282",
+    "website": "www.kinetica.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+    "burgers": [
+      {
+        "name": "The Thick Smeared Burger",
+        "description": "Exercitation laboris ullamco exercitation esse laborum aliquip voluptate amet irure consequat incididunt voluptate non.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delectable Graze",
+      "description": "Voluptate elit exercitation id veniam eu minim voluptate tempor eiusmod consequat duis."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Tavern",
+    "address": "864 Milford Street, Chicago, IL, 60644",
+    "coords": [
+      -87.723774,
+      41.911182
+    ],
+    "phone": "+1 (947) 447-3614",
+    "website": "www.newcube.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+    "burgers": [
+      {
+        "name": "The Sensational Cheesy Burger",
+        "description": "Proident sint amet dolore cupidatat ut deserunt veniam proident ex officia duis non nisi anim.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delectable Smeared Sandwich",
+        "description": "Ipsum cupidatat officia fugiat ullamco do minim.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Enticing Triple Sandwich",
+        "description": "Minim commodo officia in id occaecat aliquip quis magna quis fugiat Lorem ea adipisicing mollit.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delicious Eat",
+      "description": "Sint commodo enim in aliqua laborum velit quis sunt amet eu ea."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Tom's Café",
+    "address": "398 Newkirk Placez, Chicago, IL, 60615",
+    "coords": [
+      -87.711851,
+      41.919933
+    ],
+    "phone": "+1 (966) 467-3376",
+    "website": "www.rotodyne.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+    "burgers": [
+      {
+        "name": "The Turbo Greasy Sandwich",
+        "description": "Anim sunt cupidatat dolore occaecat laborum laborum esse ad occaecat velit consequat incididunt.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Heavenly Quadruple Burger",
+        "description": "Laboris ea adipisicing ipsum in ad dolor esse incididunt velit.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Grilled Cheesy Burger",
+        "description": "Cupidatat occaecat consectetur sunt ullamco ad culpa sit pariatur.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Enticing Graze",
+      "description": "Officia irure quis deserunt cillum."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Burgers",
+    "address": "736 Clifton Place, Chicago, IL, 60620",
+    "coords": [
+      -87.697539,
+      41.919244
+    ],
+    "phone": "+1 (894) 425-2380",
+    "website": "www.xurban.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+    "burgers": [
+      {
+        "name": "The Meaty Triple Sandwich",
+        "description": "Ad nostrud pariatur elit mollit sint et deserunt.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Delicious Quadruple Burger",
+        "description": "Velit amet commodo fugiat qui nostrud pariatur dolor esse.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delicious Smeared Sandwich",
+        "description": "Nulla Lorem enim esse nostrud amet.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Enticing Chew",
+      "description": "Ad deserunt ut dolor ex id."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Skywalker's Between the Bunz",
+    "address": "953 Sapphire Street, Chicago, IL, 60714",
+    "coords": [
+      -87.682863,
+      41.857886
+    ],
+    "phone": "+1 (911) 444-3369",
+    "website": "www.diginetic.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+    "burgers": [
+      {
+        "name": "The Filling Cheesy Sandwich",
+        "description": "Ullamco eu enim aliqua qui nulla eiusmod.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The King Kong Smeared Burger",
+        "description": "Reprehenderit aliquip mollit dolor in.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delicious Greasy Sandwich",
+        "description": "Laborum consequat id incididunt aute officia adipisicing minim in laboris et adipisicing nisi veniam cillum.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Devour",
+      "description": "Commodo ex officia tempor duis velit mollit."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Organic Bistro",
+    "address": "804 Seton Place, Chicago, IL, 60655",
+    "coords": [
+      -87.649506,
+      41.831742
+    ],
+    "phone": "+1 (942) 476-2812",
+    "website": "www.temorak.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+    "burgers": [
+      {
+        "name": "The Scrum-dilly-omcious Greasy Sandwich",
+        "description": "Lorem laborum velit pariatur fugiat.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Jedi Master Greasy Burger",
+        "description": "Eiusmod Lorem fugiat fugiat cupidatat consectetur consequat cillum quis quis aute enim fugiat.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Turbo Cheesy Sandwich",
+        "description": "Pariatur qui ullamco fugiat excepteur ea minim aliquip culpa ad excepteur non.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delectable Devour",
+      "description": "Qui dolor sit cillum sunt dolore aute culpa sunt id."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Old Ben's Fusion",
+    "address": "629 Ebony Court, Chicago, IL, 60607",
+    "coords": [
+      -87.67026,
+      41.857296
+    ],
+    "phone": "+1 (849) 543-3201",
+    "website": "www.accufarm.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+    "burgers": [
+      {
+        "name": "The Enticing Double Sandwich",
+        "description": "Tempor ipsum sunt veniam exercitation dolor eu dolor qui et.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
           "angus": false,
           "turkey": false,
           "lamb": false,
@@ -8040,9 +5334,171 @@
       "kobe": true,
       "bison": true,
       "angus": true,
-      "turkey": false,
+      "turkey": true,
       "lamb": false,
-      "elk": false
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Heavenly Graze",
+      "description": "Do adipisicing excepteur incididunt labore consectetur dolore minim et culpa duis occaecat."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Burgers",
+    "address": "297 Bay Parkway, Chicago, IL, 60617",
+    "coords": [
+      -87.681271,
+      41.908291
+    ],
+    "phone": "+1 (883) 549-3451",
+    "website": "www.translink.com",
+    "price": 2,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+    "burgers": [
+      {
+        "name": "The Meaty Greasy Sandwich",
+        "description": "Laborum reprehenderit ad Lorem sit do velit sint reprehenderit elit sint sit laboris proident.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Enticing Eat",
+      "description": "Enim adipisicing exercitation Lorem ex sit pariatur aliquip sit."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Turbo Café",
+    "address": "139 Eckford Street, Chicago, IL, 60607",
+    "coords": [
+      -87.730781,
+      41.868326
+    ],
+    "phone": "+1 (933) 573-2707",
+    "website": "www.atomica.com",
+    "price": 1,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+    "burgers": [
+      {
+        "name": "The Sensational Triple Burger",
+        "description": "Dolore dolor dolor pariatur cupidatat proident ex in voluptate dolore qui.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The King Kong Smeared Sandwich",
+        "description": "Veniam duis et in consectetur nulla.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Yummy Cheesy Sandwich",
+        "description": "Lorem mollit esse ipsum dolor elit.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
     },
     "sides": {
       "duckFries": false,
@@ -8054,59 +5510,221 @@
       "glutenFree": true
     },
     "challenges": {
-      "exists": true,
-      "name": "The Enticing Chew",
-      "description": "Voluptate commodo exercitation ad nostrud sunt et."
+      "exists": false,
+      "name": "The Yummy Eat",
+      "description": "Ad excepteur incididunt eiusmod voluptate sunt tempor aliquip qui et quis."
     },
     "hours": {
       "days": "Monday - Sunday",
       "opening": "11:00AM",
-      "closing": "8:00PM",
+      "closing": "10:00PM",
       "closed": false
     }
   },
   {
-    "name": "Sue's Lounge",
-    "address": "581 Dennett Place, Chicago, IL, 60634",
+    "name": "Bob's Pub",
+    "address": "890 Bainbridge Street, Chicago, IL, 60607",
     "coords": [
-      -87.67151,
-      41.919092
+      -87.646995,
+      41.882817
     ],
-    "phone": "+1 (825) 470-3177",
-    "website": "www.artworlds.com",
-    "price": 0,
+    "phone": "+1 (879) 432-3394",
+    "website": "www.comstar.com",
+    "price": 3,
     "foodtruck": false,
     "veggie": true,
-    "byob": true,
-    "alcohol": false,
-    "latenight": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
     "outdoor": false,
-    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
     "burgers": [
       {
-        "name": "The Delicious Double Burger",
-        "description": "Eiusmod cupidatat in ad ad nulla occaecat nisi laboris ea labore exercitation.",
-        "rating": 1,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e037b60828f31c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "name": "The Thick Triple Burger",
+        "description": "Amet id dolor excepteur officia nulla Lorem.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
         "meat": {
-          "grassfed": true,
-          "kobe": true,
-          "bison": true,
-          "angus": true,
-          "turkey": true,
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
           "lamb": true,
-          "elk": false
+          "elk": true
         }
       },
       {
-        "name": "The Jedi Master Smeared Sandwich",
-        "description": "Eiusmod non officia sunt sunt sint dolor minim dolore.",
-        "rating": 0,
-        "veggie": false,
-        "image": "https://pixabay.com/get/e03db6092cf01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "name": "The Grilled Triple Sandwich",
+        "description": "Velit cupidatat id quis est id excepteur enim ullamco laborum et ex quis magna aliquip.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
         "meat": {
           "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delectable Smeared Burger",
+        "description": "Nostrud cupidatat ut sunt labore ullamco sit deserunt.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delectable Graze",
+      "description": "Ut ut elit qui elit mollit ullamco aute consectetur deserunt quis aute exercitation nostrud irure."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "5:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Super Mario's BBQ",
+    "address": "980 Beach Place, Chicago, IL, 60617",
+    "coords": [
+      -87.6885,
+      41.827382
+    ],
+    "phone": "+1 (938) 482-2361",
+    "website": "www.isotrack.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+    "burgers": [
+      {
+        "name": "The Thick Triple Burger",
+        "description": "Do ipsum consectetur voluptate nostrud officia.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Enticing Devour",
+      "description": "Aute occaecat amet dolore sint fugiat dolore sint non magna sint ex."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Turbo Flesh & Turkey",
+    "address": "285 Garfield Place, Chicago, IL, 60647",
+    "coords": [
+      -87.679726,
+      41.859542
+    ],
+    "phone": "+1 (847) 563-2321",
+    "website": "www.waab.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+    "burgers": [
+      {
+        "name": "The King Kong Double Sandwich",
+        "description": "Laborum veniam voluptate dolor et qui voluptate cillum elit commodo.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Enticing Double Burger",
+        "description": "Laborum velit sint voluptate incididunt est aliquip qui et magna ad laboris exercitation.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": true,
           "kobe": false,
           "bison": false,
           "angus": true,
@@ -8116,16 +5734,16 @@
         }
       },
       {
-        "name": "The Meaty Greasy Sandwich",
-        "description": "Quis enim sunt nulla mollit Lorem eu irure.",
-        "rating": 0,
+        "name": "The King Kong Quadruple Burger",
+        "description": "Sit culpa dolor et culpa velit.",
+        "rating": 4,
         "veggie": false,
-        "image": "https://pixabay.com/get/e834b00821f01c2ad65a5854e74b4591e074e0c818b5144397f0c37aa5e8_640.jpg",
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
         "meat": {
           "grassfed": true,
-          "kobe": true,
+          "kobe": false,
           "bison": true,
-          "angus": true,
+          "angus": false,
           "turkey": false,
           "lamb": false,
           "elk": true
@@ -8135,10 +5753,301 @@
     "meats": {
       "grassfed": false,
       "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Yummy Eat",
+      "description": "Cillum laboris adipisicing nostrud ex fugiat mollit aliquip culpa adipisicing sunt fugiat."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bob's Cantina",
+    "address": "995 Hoyts Lane, Chicago, IL, 60660",
+    "coords": [
+      -87.684125,
+      41.914109
+    ],
+    "phone": "+1 (921) 564-2942",
+    "website": "www.genmom.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+    "burgers": [
+      {
+        "name": "The Enticing Quadruple Sandwich",
+        "description": "In nulla magna deserunt commodo dolor non eiusmod Lorem nisi officia anim consectetur dolor.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delicious Greasy Burger",
+        "description": "Minim exercitation tempor adipisicing anim ut enim consequat tempor consequat ad.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The King Kong Quadruple Sandwich",
+        "description": "Et elit minim ea commodo in mollit.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Eat",
+      "description": "Do aliqua officia laborum elit nulla."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Buffet",
+    "address": "437 Greene Avenue, Chicago, IL, 60642",
+    "coords": [
+      -87.683442,
+      41.834034
+    ],
+    "phone": "+1 (868) 472-2585",
+    "website": "www.geekosis.com",
+    "price": 1,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/22/15/42/burger-951896_150.jpg",
+    "burgers": [
+      {
+        "name": "The Filling Smeared Burger",
+        "description": "Esse amet commodo ipsum nisi.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Grilled Smeared Sandwich",
+        "description": "Nulla laborum sit labore proident nostrud voluptate sunt pariatur sint cupidatat ad.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Filling Greasy Sandwich",
+        "description": "Est adipisicing adipisicing veniam ut velit aute est.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
       "bison": true,
       "angus": true,
       "turkey": true,
       "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Enticing Graze",
+      "description": "Eiusmod fugiat consectetur id qui nostrud commodo in tempor eu eiusmod."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Super Mario's Between the Bunz",
+    "address": "167 Nova Court, Chicago, IL, 60610",
+    "coords": [
+      -87.703776,
+      41.827743
+    ],
+    "phone": "+1 (875) 490-2950",
+    "website": "www.ontagene.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delightful Smeared Burger",
+        "description": "Quis occaecat non excepteur dolore esse qui excepteur est et.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Jedi Master Cheesy Sandwich",
+        "description": "Aute Lorem et qui non.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The King Kong Quadruple Burger",
+        "description": "Anim eu dolor ad exercitation non et tempor deserunt.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
       "elk": false
     },
     "sides": {
@@ -8153,12 +6062,2199 @@
     "challenges": {
       "exists": false,
       "name": "The Delicious Devour",
-      "description": "Reprehenderit laboris aute exercitation laboris eu irure anim labore quis ad fugiat."
+      "description": "Laborum velit enim non ut sunt ut anim esse esse aliquip deserunt est laboris non."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Flesh & Turkey",
+    "address": "863 Russell Street, Chicago, IL, 60605",
+    "coords": [
+      -87.662972,
+      41.851861
+    ],
+    "phone": "+1 (929) 485-3842",
+    "website": "www.synkgen.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delicious Smeared Sandwich",
+        "description": "Mollit enim labore proident enim adipisicing ipsum labore consectetur sunt.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delightful Triple Burger",
+        "description": "Adipisicing do laboris duis ex aliquip mollit tempor pariatur exercitation tempor tempor dolor elit nulla.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Yummy Cheesy Burger",
+        "description": "Est magna deserunt mollit incididunt.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Meaty Devour",
+      "description": "Anim duis pariatur est cupidatat ad amet ullamco magna id sunt."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Between the Bunz",
+    "address": "475 Meadow Street, Chicago, IL, 60645",
+    "coords": [
+      -87.737925,
+      41.892457
+    ],
+    "phone": "+1 (801) 510-2197",
+    "website": "www.tubesys.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+    "burgers": [
+      {
+        "name": "The Sensational Double Burger",
+        "description": "Voluptate deserunt est exercitation ut fugiat enim consectetur proident veniam nostrud ipsum aliquip veniam.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Enticing Double Sandwich",
+        "description": "Veniam aliqua eiusmod labore pariatur magna amet nulla dolore aliquip enim.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Eat",
+      "description": "Consectetur reprehenderit occaecat excepteur sit ipsum fugiat labore pariatur veniam."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Super Mario's Lounge",
+    "address": "525 Bushwick Court, Chicago, IL, 60068",
+    "coords": [
+      -87.67924,
+      41.857866
+    ],
+    "phone": "+1 (998) 457-2513",
+    "website": "www.zeam.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delightful Smeared Sandwich",
+        "description": "Consequat cupidatat dolore Lorem laboris elit exercitation ea qui ad deserunt.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Turbo Double Sandwich",
+        "description": "In proident ullamco minim aliquip cupidatat occaecat officia ut cupidatat qui esse ut excepteur officia.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delicious Graze",
+      "description": "Fugiat pariatur consequat laboris ea culpa voluptate adipisicing aute quis officia."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Pub",
+    "address": "717 Franklin Avenue, Chicago, IL, 60620",
+    "coords": [
+      -87.695094,
+      41.885408
+    ],
+    "phone": "+1 (996) 597-2359",
+    "website": "www.isosphere.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+    "burgers": [
+      {
+        "name": "The Meaty Double Burger",
+        "description": "Reprehenderit consequat adipisicing id cillum aute est.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delicious Cheesy Sandwich",
+        "description": "Aliquip anim qui sit esse do officia.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Devour",
+      "description": "Officia nulla ad amet est elit occaecat non mollit voluptate."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon BBQ",
+    "address": "754 India Street, Chicago, IL, 60630",
+    "coords": [
+      -87.699807,
+      41.8616
+    ],
+    "phone": "+1 (891) 536-2745",
+    "website": "www.biohab.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+    "burgers": [
+      {
+        "name": "The King Kong Triple Burger",
+        "description": "Dolore quis duis elit do nostrud.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Delightful Quadruple Sandwich",
+        "description": "Fugiat aliqua adipisicing ipsum amet aute dolor pariatur quis ut in.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Heavenly Devour",
+      "description": "Cupidatat velit deserunt officia minim aute."
     },
     "hours": {
       "days": "Monday - Sunday",
       "opening": "8:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Bistro",
+    "address": "603 Church Lane, Chicago, IL, 60617",
+    "coords": [
+      -87.723494,
+      41.840099
+    ],
+    "phone": "+1 (870) 518-2701",
+    "website": "www.hydrocom.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+    "burgers": [
+      {
+        "name": "The Filling Triple Sandwich",
+        "description": "Nisi dolor cillum occaecat non aute laboris ea elit ipsum adipisicing.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Meaty Chew",
+      "description": "Magna ea laboris est consequat in sint."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Between the Bunz",
+    "address": "617 Gatling Place, Chicago, IL, 60616",
+    "coords": [
+      -87.701345,
+      41.851896
+    ],
+    "phone": "+1 (919) 410-3476",
+    "website": "www.opticom.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+    "burgers": [
+      {
+        "name": "The Thick Double Burger",
+        "description": "Laboris sunt in aliqua ipsum.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": true,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delicious Eat",
+      "description": "Id culpa laboris nostrud eiusmod."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bob's BBQ",
+    "address": "990 Brown Street, Chicago, IL, 60652",
+    "coords": [
+      -87.701224,
+      41.827554
+    ],
+    "phone": "+1 (874) 429-2359",
+    "website": "www.quarex.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+    "burgers": [
+      {
+        "name": "The Scrumtrulesant Quadruple Sandwich",
+        "description": "In in commodo elit culpa.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Chew",
+      "description": "Dolor tempor exercitation quis magna officia excepteur qui in laboris."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bowsers Buffet",
+    "address": "589 Vandam Street, Chicago, IL, 60657",
+    "coords": [
+      -87.682883,
+      41.927955
+    ],
+    "phone": "+1 (884) 553-2650",
+    "website": "www.terragen.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delightful Cheesy Burger",
+        "description": "Irure deserunt nisi qui dolore dolore ullamco sunt esse Lorem id ipsum exercitation consectetur tempor.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": true,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delicious Chew",
+      "description": "Est reprehenderit commodo culpa aute pariatur non ea voluptate deserunt esse fugiat qui reprehenderit irure."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Skywalker's Bistro",
+    "address": "729 Neptune Avenue, Chicago, IL, 60657",
+    "coords": [
+      -87.697428,
+      41.856504
+    ],
+    "phone": "+1 (833) 562-2428",
+    "website": "www.lexicondo.com",
+    "price": 2,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/11/burger-945321_150.jpg",
+    "burgers": [
+      {
+        "name": "The Enticing Smeared Sandwich",
+        "description": "Elit labore laboris in consequat proident pariatur officia aute sit.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Jedi Master Smeared Sandwich",
+        "description": "Consequat sit duis commodo labore Lorem commodo occaecat duis anim laboris consequat occaecat.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Enticing Quadruple Burger",
+        "description": "Ut minim culpa proident do aliquip sit cillum consequat laboris dolor qui.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Yummy Chew",
+      "description": "Consectetur deserunt reprehenderit enim dolore ipsum aliqua ipsum adipisicing ex ut proident."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Skywalker's Burgers",
+    "address": "491 Exeter Street, Chicago, IL, 60614",
+    "coords": [
+      -87.715167,
+      41.901746
+    ],
+    "phone": "+1 (824) 597-3440",
+    "website": "www.techade.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+    "burgers": [
+      {
+        "name": "The Grilled Smeared Burger",
+        "description": "Dolor quis id culpa ut nisi incididunt.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delicious Smeared Sandwich",
+        "description": "Aute incididunt officia nostrud pariatur.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Heavenly Triple Burger",
+        "description": "In non eu commodo nulla.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/19/burger-1015438_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Meaty Devour",
+      "description": "Fugiat officia esse cupidatat excepteur esse Lorem est quis elit labore ipsum dolore incididunt fugiat."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "5:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Skywalker's Tavern",
+    "address": "862 Nassau Street, Chicago, IL, 60610",
+    "coords": [
+      -87.722718,
+      41.86335
+    ],
+    "phone": "+1 (860) 522-2543",
+    "website": "www.daycore.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+    "burgers": [
+      {
+        "name": "The Yummy Triple Burger",
+        "description": "Fugiat proident ex occaecat cupidatat esse nostrud cupidatat.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Meaty Chew",
+      "description": "Veniam voluptate aute mollit Lorem."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "5:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Turbo Tavern",
+    "address": "490 Empire Boulevard, Chicago, IL, 60619",
+    "coords": [
+      -87.652582,
+      41.856584
+    ],
+    "phone": "+1 (863) 494-3353",
+    "website": "www.senmao.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+    "burgers": [
+      {
+        "name": "The Heavenly Triple Sandwich",
+        "description": "Ex velit id Lorem mollit.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Graze",
+      "description": "Commodo excepteur reprehenderit ea excepteur."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
       "closing": "12:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Tavern",
+    "address": "556 Tompkins Avenue, Chicago, IL, 60604",
+    "coords": [
+      -87.675513,
+      41.904091
+    ],
+    "phone": "+1 (859) 415-3655",
+    "website": "www.comtest.com",
+    "price": 2,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+    "burgers": [
+      {
+        "name": "The Sensational Cheesy Burger",
+        "description": "Veniam ea exercitation laboris esse.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Grilled Quadruple Sandwich",
+        "description": "Culpa in laboris sunt consectetur deserunt ut elit voluptate ad consequat.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delicious Quadruple Sandwich",
+        "description": "Non dolor sit ipsum consectetur aute aliqua enim et elit nostrud.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Enticing Graze",
+      "description": "Sunt do dolore minim reprehenderit proident ipsum excepteur deserunt occaecat enim ad."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "10:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Flesh & Turkey",
+    "address": "421 Bryant Street, Chicago, IL, 60714",
+    "coords": [
+      -87.657465,
+      41.82994
+    ],
+    "phone": "+1 (942) 542-3966",
+    "website": "www.dragbot.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+    "burgers": [
+      {
+        "name": "The Enticing Double Burger",
+        "description": "Eiusmod in nisi id qui tempor tempor culpa eu consectetur incididunt et.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delightful Double Sandwich",
+        "description": "Exercitation sunt aliquip veniam ea occaecat nostrud aute ipsum deserunt nostrud ea voluptate elit duis.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Grilled Double Burger",
+        "description": "Ea aute cupidatat aute labore minim.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/30/18/23/burger-868145_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Yummy Chew",
+      "description": "Consectetur labore laborum ad duis est laborum."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "12:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Tom's Bar",
+    "address": "207 Howard Alley, Chicago, IL, 60639",
+    "coords": [
+      -87.705605,
+      41.903543
+    ],
+    "phone": "+1 (860) 423-2820",
+    "website": "www.neocent.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+    "burgers": [
+      {
+        "name": "The Sensational Cheesy Burger",
+        "description": "Non nostrud magna labore cupidatat amet non fugiat Lorem elit.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Yummy Graze",
+      "description": "Lorem nulla ex nostrud ad."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Buffet",
+    "address": "270 Tudor Terrace, Chicago, IL, 60656",
+    "coords": [
+      -87.7341,
+      41.918145
+    ],
+    "phone": "+1 (998) 550-2490",
+    "website": "www.panzent.com",
+    "price": 3,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delightful Cheesy Sandwich",
+        "description": "Laborum nisi veniam adipisicing labore aute pariatur veniam sint exercitation dolor laborum velit quis.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Heavenly Smeared Sandwich",
+        "description": "Occaecat fugiat excepteur est aliqua do aliqua aliquip qui eu mollit reprehenderit excepteur amet dolore.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Scrumtrulesant Quadruple Sandwich",
+        "description": "Sint dolor commodo amet consectetur laborum velit amet id velit consequat esse culpa consectetur id.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/19/18/47/burger-851847_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Meaty Eat",
+      "description": "Officia laboris nostrud tempor consequat laboris ad."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "11:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet BBQ",
+    "address": "276 Gerry Street, Chicago, IL, 60615",
+    "coords": [
+      -87.723797,
+      41.8865
+    ],
+    "phone": "+1 (982) 569-2572",
+    "website": "www.accel.com",
+    "price": 1,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/19/14/05/burger-996037_150.jpg",
+    "burgers": [
+      {
+        "name": "The Heavenly Triple Sandwich",
+        "description": "Ut commodo fugiat aliqua veniam reprehenderit in dolore consectetur eiusmod dolore ad sit ad.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Delicious Triple Burger",
+        "description": "Tempor deserunt reprehenderit cupidatat dolor aliqua enim.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The King Kong Double Sandwich",
+        "description": "Consectetur excepteur labore ipsum proident ut ex culpa commodo.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": false,
+      "turkey": true,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delicious Graze",
+      "description": "Aliqua consectetur exercitation irure occaecat reprehenderit."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "5:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Turbo Pub",
+    "address": "320 Clay Street, Chicago, IL, 60707",
+    "coords": [
+      -87.699311,
+      41.857309
+    ],
+    "phone": "+1 (929) 590-2887",
+    "website": "www.kindaloo.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+    "burgers": [
+      {
+        "name": "The Meaty Double Sandwich",
+        "description": "Aliqua id adipisicing ipsum aliquip commodo labore duis anim eu ea consectetur veniam.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Jedi Master Cheesy Burger",
+        "description": "Laboris proident cillum et irure esse.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": true
+        }
+      },
+      {
+        "name": "The King Kong Triple Burger",
+        "description": "Id nulla ipsum anim veniam elit do anim dolor deserunt enim et esse occaecat amet.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": false,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Eat",
+      "description": "Culpa occaecat occaecat culpa cillum proident aliquip cupidatat."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "9:00AM",
+      "closing": "6:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Gourmet Chophouse",
+    "address": "745 Townsend Street, Chicago, IL, 60630",
+    "coords": [
+      -87.733884,
+      41.847237
+    ],
+    "phone": "+1 (974) 515-2684",
+    "website": "www.equicom.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+    "burgers": [
+      {
+        "name": "The Scrumtrulesant Double Burger",
+        "description": "Laboris aliqua ea excepteur dolor ipsum ea.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Eat",
+      "description": "Culpa magna ex velit incididunt qui deserunt officia nostrud sint reprehenderit consequat pariatur fugiat."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "7:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bowsers Flesh & Turkey",
+    "address": "834 Bartlett Place, Chicago, IL, 60617",
+    "coords": [
+      -87.695378,
+      41.83007
+    ],
+    "phone": "+1 (833) 505-3426",
+    "website": "www.viocular.com",
+    "price": 1,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": false,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+    "burgers": [
+      {
+        "name": "The Delectable Cheesy Burger",
+        "description": "Deserunt Lorem aliquip ex voluptate pariatur incididunt ipsum ea anim mollit pariatur eiusmod duis.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/15/02/pizza-burger-948403_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The King Kong Greasy Burger",
+        "description": "Sint fugiat esse consequat aliqua.",
+        "rating": 4,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": false,
+      "bison": true,
+      "angus": false,
+      "turkey": true,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Heavenly Devour",
+      "description": "Occaecat ea officia eiusmod do non laborum ea Lorem in ad nulla pariatur."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "5:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Super Mario's Lounge",
+    "address": "926 Sullivan Street, Chicago, IL, 60656",
+    "coords": [
+      -87.636283,
+      41.885819
+    ],
+    "phone": "+1 (878) 556-3022",
+    "website": "www.zillanet.com",
+    "price": 2,
+    "foodtruck": true,
+    "veggie": false,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/10/14/13/55/burgers-987644_150.jpg",
+    "burgers": [
+      {
+        "name": "The Yummy Greasy Sandwich",
+        "description": "Qui id duis sit sint fugiat.",
+        "rating": 1,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Thick Cheesy Burger",
+        "description": "Quis tempor sint reprehenderit ut qui.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": true,
+      "angus": false,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Meaty Graze",
+      "description": "Occaecat labore anim aute occaecat."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "5:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Old Ben's Tavern",
+    "address": "485 Beard Street, Chicago, IL, 60621",
+    "coords": [
+      -87.731915,
+      41.830067
+    ],
+    "phone": "+1 (904) 492-3877",
+    "website": "www.cuizine.com",
+    "price": 3,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": false,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827308_150.jpg",
+    "burgers": [
+      {
+        "name": "The Turbo Triple Burger",
+        "description": "Et do proident officia consequat nostrud ea tempor ullamco eu.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827309_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": false,
+      "turkey": false,
+      "lamb": false,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Graze",
+      "description": "Laborum in ullamco consectetur aute occaecat sunt consectetur ad laboris elit amet."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "10:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Lounge",
+    "address": "308 Willmohr Street, Chicago, IL, 60641",
+    "coords": [
+      -87.691751,
+      41.848639
+    ],
+    "phone": "+1 (926) 441-3711",
+    "website": "www.geostele.com",
+    "price": 2,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": true,
+    "alcohol": false,
+    "latenight": true,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+    "burgers": [
+      {
+        "name": "The Meaty Cheesy Sandwich",
+        "description": "Labore veniam ipsum dolor aliquip do aute amet Lorem do duis.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/13/21/09/sandwich-986799_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Turbo Greasy Sandwich",
+        "description": "Esse dolor duis occaecat qui occaecat aliquip mollit magna enim aliqua irure.",
+        "rating": 2,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/07/01/07/06/burger-827310_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": true,
+      "lamb": true,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": false
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Delicious Eat",
+      "description": "Laboris mollit occaecat non sint ad minim aute irure."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "11:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bob's Chophouse",
+    "address": "688 Blake Avenue, Chicago, IL, 60606",
+    "coords": [
+      -87.645703,
+      41.848085
+    ],
+    "phone": "+1 (803) 415-3666",
+    "website": "www.zilencio.com",
+    "price": 2,
+    "foodtruck": false,
+    "veggie": false,
+    "byob": true,
+    "alcohol": true,
+    "latenight": false,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2014/10/23/18/05/burger-500054_150.jpg",
+    "burgers": [
+      {
+        "name": "The Filling Double Sandwich",
+        "description": "Incididunt nulla sint do dolore eu amet amet minim sit eiusmod elit.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/10/31/12/20/burger-1015440_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": true,
+          "elk": true
+        }
+      },
+      {
+        "name": "The Scrum-dilly-omcious Double Sandwich",
+        "description": "Consequat nisi qui est eu elit laborum laborum enim.",
+        "rating": 2,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/04/20/13/25/burger-731298_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Thick Triple Sandwich",
+        "description": "Ex sit enim fugiat voluptate deserunt nostrud velit.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/06/08/15/13/hamburger-801942_150.jpg",
+        "meat": {
+          "grassfed": true,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": false,
+      "kobe": true,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": true,
+      "elk": true
+    },
+    "sides": {
+      "duckFries": true,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": false
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Meaty Graze",
+      "description": "Dolore quis irure commodo dolore labore laboris incididunt laborum voluptate dolor et."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "8:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Sue's Bistro",
+    "address": "147 Bergen Avenue, Chicago, IL, 60608",
+    "coords": [
+      -87.697683,
+      41.833837
+    ],
+    "phone": "+1 (837) 531-2073",
+    "website": "www.qaboos.com",
+    "price": 4,
+    "foodtruck": false,
+    "veggie": true,
+    "byob": true,
+    "alcohol": true,
+    "latenight": true,
+    "outdoor": false,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+    "burgers": [
+      {
+        "name": "The Grilled Greasy Sandwich",
+        "description": "Non cupidatat enim amet sint aliquip incididunt Lorem et exercitation ea eiusmod proident et mollit.",
+        "rating": 3,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/20/02/31/pizza-pocket-947899_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": true,
+          "angus": false,
+          "turkey": false,
+          "lamb": false,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Yummy Quadruple Sandwich",
+        "description": "Ullamco velit deserunt id ullamco cupidatat ipsum ex non tempor dolore mollit et.",
+        "rating": 3,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": false,
+          "bison": true,
+          "angus": true,
+          "turkey": false,
+          "lamb": true,
+          "elk": false
+        }
+      },
+      {
+        "name": "The Yummy Quadruple Burger",
+        "description": "Culpa mollit laboris tempor sit.",
+        "rating": 4,
+        "veggie": false,
+        "image": "https://pixabay.com/static/uploads/photo/2015/09/18/10/12/burger-945322_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": true,
+          "turkey": true,
+          "lamb": false,
+          "elk": true
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": true,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": true,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": false,
+      "name": "The Meaty Chew",
+      "description": "Aute ut occaecat cupidatat enim sunt."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "12:00AM",
+      "closing": "9:00PM",
+      "closed": false
+    }
+  },
+  {
+    "name": "Bacon Buffet",
+    "address": "587 Williamsburg Street, Chicago, IL, 60641",
+    "coords": [
+      -87.665636,
+      41.8284
+    ],
+    "phone": "+1 (820) 420-2801",
+    "website": "www.acruex.com",
+    "price": 4,
+    "foodtruck": true,
+    "veggie": true,
+    "byob": false,
+    "alcohol": false,
+    "latenight": false,
+    "outdoor": true,
+    "image": "https://pixabay.com/static/uploads/photo/2015/09/01/03/42/food-916397_150.jpg",
+    "burgers": [
+      {
+        "name": "The Jedi Master Greasy Sandwich",
+        "description": "Nostrud ex tempor incididunt ex nulla officia.",
+        "rating": 1,
+        "veggie": true,
+        "image": "https://pixabay.com/static/uploads/photo/2015/08/04/10/48/burger-874531_150.jpg",
+        "meat": {
+          "grassfed": false,
+          "kobe": true,
+          "bison": false,
+          "angus": false,
+          "turkey": true,
+          "lamb": false,
+          "elk": false
+        }
+      }
+    ],
+    "meats": {
+      "grassfed": true,
+      "kobe": false,
+      "bison": false,
+      "angus": true,
+      "turkey": false,
+      "lamb": false,
+      "elk": false
+    },
+    "sides": {
+      "duckFries": false,
+      "tots": false,
+      "macAndCheese": true
+    },
+    "allergies": {
+      "accommodates": false,
+      "glutenFree": true
+    },
+    "challenges": {
+      "exists": true,
+      "name": "The Delectable Graze",
+      "description": "Cupidatat labore proident amet ut consequat amet pariatur commodo incididunt amet exercitation dolor."
+    },
+    "hours": {
+      "days": "Monday - Sunday",
+      "opening": "8:00AM",
+      "closing": "11:00PM",
       "closed": false
     }
   }

--- a/routes/location.js
+++ b/routes/location.js
@@ -52,15 +52,23 @@ router.get('/detail/data', function(req, res, next) {
 router.post('/q', function(req, res, next) {
   // JSON object sent are search terms
   console.log("==============");
-  console.log(req);
+  // console.log(req);
   console.log(req.body);
-  var search = req.body;
+  var search = (req.body);
+  for (var term in search) {
+    if (search.hasOwnProperty(term)) {
+      search[term] = true;
+    };
+  };
   console.log(search);
   // query database by the JSON
   model.find(search,function(err, locations) {
     if (err) {
       res.json(buildErrorResponse(err));
     } else {
+      console.log("==============");
+      console.log("==============");
+      console.log(locations);
       res.json(locations);
     }
   });
@@ -83,7 +91,7 @@ router.post('/set-session/:id', function(req, res, next) {
 router.post('/set-session', function(req, res, next) {
   req.session.search = req.body;
   console.log("session saved via req.body");
-  // console.log(req.session.search);
+  console.log(req.session.search);
   res.render('map', {user : req.user});
 });
 

--- a/views/search.hbs
+++ b/views/search.hbs
@@ -110,6 +110,7 @@
         return;
       }
       if (xhr.status == 200) {
+        console.log(xhr.responseText);
         setSession(xhr.responseText);
       }
     };


### PR DESCRIPTION
Searching issue: once again, 'string' issues with the searching. We need to stringify to upload, but mongo doesn't seems like like { veggie:'true' } it wants just { veggie:true }, so this is being done on the server side.

Location Seed: Noticed that the image urls (burger detail) are broken. Perhaps the big format images on pixabay are only good for a few days and then the url is changed? Either way, switched them back to the webformatURL (smaller size) just so there are at least images. Crappy quality images, but images. 
